### PR TITLE
Basestring does not exist in python3. Use str instead.

### DIFF
--- a/fastavro/six.py
+++ b/fastavro/six.py
@@ -26,6 +26,8 @@ if sys.version_info >= (3, 0):
     def py3_json_dump(obj, indent):
         json.dump(obj, stdout, indent=indent)
 
+    basestring = str
+
 else:  # Python 2x
     from cStringIO import StringIO as MemoryIO  # NOQA
     xrange = xrange
@@ -43,6 +45,8 @@ else:  # Python 2x
 
     def py2_json_dump(obj, indent):
         json.dump(obj, stdout, indent=indent, encoding=_outenc)
+
+    basestring = basestring
 
 # We do it this way and not just redifine function since Cython do not like it
 if sys.version_info >= (3, 0):

--- a/fastavro/writer.py
+++ b/fastavro/writer.py
@@ -7,11 +7,11 @@
 # Apache 2.0 license (http://www.apache.org/licenses/LICENSE-2.0)
 
 try:
-    from ._six import utob, MemoryIO, long
+    from ._six import utob, MemoryIO, long, basestring
     from ._reader import HEADER_SCHEMA, SYNC_SIZE, MAGIC
     from ._schema import acquaint_schema, extract_record_type
 except ImportError:
-    from .six import utob, MemoryIO, long
+    from .six import utob, MemoryIO, long, basestring
     from .reader import HEADER_SCHEMA, SYNC_SIZE, MAGIC
     from .schema import acquaint_schema, extract_record_type
 


### PR DESCRIPTION
In python3 basestring does not exist and str should be used instead.
Compare string_types https://pythonhosted.org/six/#constants.
Parallel to what was done before I added this into the existing six.py file. 