### PR TITLE
Detect unknown types

### DIFF
--- a/fastavro/reader.py
+++ b/fastavro/reader.py
@@ -12,14 +12,14 @@ from struct import unpack
 from zlib import decompress
 
 try:
-    from ._six import MemoryIO, xrange, btou
+    from ._six import MemoryIO, xrange, btou, utob
     from ._schema import acquaint_schema, extract_record_type
 except ImportError:
-    from .six import MemoryIO, xrange, btou
+    from .six import MemoryIO, xrange, btou, utob
     from .schema import acquaint_schema, extract_record_type
 
 VERSION = 1
-MAGIC = 'Obj' + chr(VERSION)
+MAGIC = b'Obj' + utob(chr(VERSION))
 SYNC_SIZE = 16
 HEADER_SCHEMA = {
     'type': 'record',
@@ -319,9 +319,10 @@ class iter_avro:
         except StopIteration:
             raise ValueError('cannot read header - is it an avro file?')
 
+        # `meta` values are bytes. So, the actual decoding has to be external.
         self.schema = schema = \
             json.loads(btou(self._header['meta']['avro.schema']))
-        self.codec = btou(self._header['meta'].get('avro.codec', 'null'))
+        self.codec = btou(self._header['meta'].get('avro.codec', b'null'))
 
         acquaint_schema(schema)
         self._records = _iter_avro(fo, self._header, self.codec, schema)

--- a/fastavro/schema.py
+++ b/fastavro/schema.py
@@ -5,10 +5,10 @@ def acquaint_schema(schema):
     # TODO: Untangle this recursive dependency
     try:
         from ._reader import READERS, read_data
-        from ._writer import CUSTOM_SCHEMAS, WRITERS, write_data
+        from ._writer import SCHEMA_DEFS, WRITERS, write_data
     except ImportError:
         from .reader import READERS, read_data
-        from .writer import CUSTOM_SCHEMAS, WRITERS, write_data
+        from .writer import SCHEMA_DEFS, WRITERS, write_data
 
     extract_named_schemas_into_repo(
         schema,
@@ -22,7 +22,7 @@ def acquaint_schema(schema):
     )
     extract_named_schemas_into_repo(
         schema,
-        CUSTOM_SCHEMAS,
+        SCHEMA_DEFS,
         lambda schema: schema,
     )
 

--- a/fastavro/six.py
+++ b/fastavro/six.py
@@ -20,11 +20,11 @@ if sys.version_info >= (3, 0):
     def py3_utob(n, encoding=_encoding):
         return bytes(n, encoding)
 
-    unicode = str
-    long = int
-
     def py3_json_dump(obj, indent):
         json.dump(obj, stdout, indent=indent)
+
+    def py3_dict_iteritems(dict_):
+        return dict_.items()
 
 else:  # Python 2x
     from cStringIO import StringIO as MemoryIO  # NOQA
@@ -36,20 +36,26 @@ else:  # Python 2x
     def py2_utob(n, encoding=_encoding):
         return n.encode(encoding)
 
-    unicode = unicode
-    long = long
-
     _outenc = getattr(stdout, 'encoding', None) or _encoding
 
     def py2_json_dump(obj, indent):
         json.dump(obj, stdout, indent=indent, encoding=_outenc)
+
+    def py2_dict_iteritems(dict_):
+        return dict_.iteritems()
 
 # We do it this way and not just redifine function since Cython do not like it
 if sys.version_info >= (3, 0):
     btou = py3_btou
     utob = py3_utob
     json_dump = py3_json_dump
+    basetring_typespec = (bytes, str,)
+    long = int
+    dict_iteritems = py3_dict_iteritems
 else:
     btou = py2_btou
     utob = py2_utob
     json_dump = py2_json_dump
+    basetring_typespec = (basestring,) # flake8: noqa
+    dict_iteritems = py2_dict_iteritems
+    long = long

--- a/fastavro/writer.py
+++ b/fastavro/writer.py
@@ -205,8 +205,8 @@ def validate(datum, schema):
             )
         )
 
-    if record_type in CUSTOM_SCHEMAS:
-        return validate(datum, CUSTOM_SCHEMAS[record_type])
+    if record_type in SCHEMA_DEFS:
+        return validate(datum, SCHEMA_DEFS[record_type])
 
     raise ValueError("I don't know what a {0} is.".format(record_type))
 
@@ -256,7 +256,16 @@ WRITERS = {
     'record': write_record,
 }
 
-CUSTOM_SCHEMAS = {}
+SCHEMA_DEFS = {
+    'null': 'null',
+    'boolean': 'boolean',
+    'string': 'string',
+    'int': 'int',
+    'long': 'long',
+    'float': 'float',
+    'double': 'double',
+    'bytes': 'bytes',
+}
 
 
 def write_data(fo, datum, schema):

--- a/fastavro/writer.py
+++ b/fastavro/writer.py
@@ -7,11 +7,11 @@
 # Apache 2.0 license (http://www.apache.org/licenses/LICENSE-2.0)
 
 try:
-    from ._six import utob, MemoryIO, long
+    from ._six import utob, MemoryIO, long, basetring_typespec, dict_iteritems
     from ._reader import HEADER_SCHEMA, SYNC_SIZE, MAGIC
     from ._schema import acquaint_schema, extract_record_type
 except ImportError:
-    from .six import utob, MemoryIO, long
+    from .six import utob, MemoryIO, long, basetring_typespec, dict_iteritems
     from .reader import HEADER_SCHEMA, SYNC_SIZE, MAGIC
     from .schema import acquaint_schema, extract_record_type
 
@@ -37,7 +37,7 @@ def write_null(fo, datum, schema=None):
 def write_boolean(fo, datum, schema=None):
     '''A boolean is written as a single byte whose value is either 0 (false) or
     1 (true).'''
-    fo.write(chr(1) if datum else chr(0))
+    fo.write(b'1' if datum else b'0')
 
 
 def write_int(fo, datum, schema=None):
@@ -45,9 +45,9 @@ def write_int(fo, datum, schema=None):
     '''
     datum = (datum << 1) ^ (datum >> 63)
     while (datum & ~0x7F) != 0:
-        fo.write(chr((datum & 0x7f) | 0x80))
+        fo.write(pack('B', (datum & 0x7f) | 0x80))
         datum >>= 7
-    fo.write(chr(datum))
+    fo.write(pack('B', datum))
 
 write_long = write_int
 
@@ -129,7 +129,7 @@ def write_map(fo, datum, schema):
     if len(datum) > 0:
         write_long(fo, len(datum))
         vtype = schema['values']
-        for key, val in datum.iteritems():
+        for key, val in dict_iteritems(datum):
             write_utf8(fo, key)
             write_data(fo, val, vtype)
     write_long(fo, 0)
@@ -153,7 +153,7 @@ def validate(datum, schema):
         return isinstance(datum, bool)
 
     if record_type == 'string':
-        return isinstance(datum, basestring)
+        return isinstance(datum, basetring_typespec)
 
     if record_type == 'bytes':
         return isinstance(datum, str)
@@ -192,7 +192,7 @@ def validate(datum, schema):
     if record_type == 'map':
         return (
             isinstance(datum, Mapping)
-            and all(isinstance(k, basestring) for k in datum.keys())
+            and all(isinstance(k, basetring_typespec) for k in datum.keys())
             and all(validate(v, schema['values']) for v in datum.values())
         )
 

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -56,3 +56,41 @@ def test_not_avro():
         assert False, 'opened non avro file'
     except ValueError:
         pass
+
+
+def test_acquaint_schema_rejects_undleclared_name():
+    try:
+        fastavro.schema.acquaint_schema({
+            "type": "record",
+            "fields": [{
+                "name": "left",
+                "type": "Thinger",
+            }]
+        })
+        assert False, 'Never raised'
+    except fastavro.schema.UnknownType as e:
+        assert 'Thinger' == e.fullname
+
+
+def test_acquaint_schema_rejects_unordered_references():
+    try:
+        fastavro.schema.acquaint_schema({
+            "type": "record",
+            "fields": [{
+                "name": "left",
+                "type": "Thinger"
+            }, {
+                "name": "right",
+                "type": {
+                    "type": "record",
+                    "name": "Thinger",
+                    "fields": [{
+                        "name": "the_thing",
+                        "type": "string"
+                    }]
+                }
+            }]
+        })
+        assert False, 'Never raised'
+    except fastavro.schema.UnknownType as e:
+        assert 'Thinger' == e.fullname


### PR DESCRIPTION
Raise a `fastavro.schema.UnknownType` every time we try to use an unknown type definition (refer to a name we haven't defined yet, mostly).