### PR TITLE
Add enclosing namespace to unqualified references

### DIFF
--- a/fastavro/schema.py
+++ b/fastavro/schema.py
@@ -1,6 +1,18 @@
 # cython: auto_cpdef=True
 
 
+PRIMITIVES = set([
+    'boolean',
+    'bytes',
+    'double',
+    'float',
+    'int',
+    'long',
+    'null',
+    'string',
+])
+
+
 class UnknownType(Exception):
     def __init__(self, name):
         super(UnknownType, self).__init__(name)
@@ -67,6 +79,12 @@ def extract_named_schemas_into_repo(schema, repo, transformer, parent_ns=None):
         return
 
     if type(schema) != dict:
+        # If a reference to another schema is an unqualified name, but not one
+        # of the primitive types, then we should add the current enclosing
+        # namespace to reference name.
+        if schema not in PRIMITIVES and '.' not in schema and parent_ns:
+            schema = parent_ns + '.' + schema
+
         if schema not in repo:
             raise UnknownType(schema)
         return

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -94,3 +94,33 @@ def test_acquaint_schema_rejects_unordered_references():
         assert False, 'Never raised'
     except fastavro.schema.UnknownType as e:
         assert 'Thinger' == e.name
+
+
+def test_acquaint_schema_accepts_nested_namespaces():
+    try:
+        fastavro.schema.acquaint_schema({
+            "namespace": "com.example",
+            "name": "Outer",
+            "type": "record",
+            "fields": [{
+                "name": "a",
+                "type": {
+                    "type": "record",
+                    "name": "Inner",
+                    "fields": [{
+                        "name": "the_thing",
+                        "type": "string"
+                    }]
+                }
+            }, {
+                "name": "b",
+                # This should resolve to com.example.Inner because of the
+                # `namespace` of the enclosing record.
+                "type": "Inner"
+            }, {
+                "name": "b",
+                "type": "com.example.Inner"
+            }]
+        })
+    except fastavro.schema.UnknownType:
+        assert False, 'Should not get exception'


### PR DESCRIPTION
When you refer to a previously defined schema using an unqualified name, and there's an enclosing `namespace` to work with, we need to [join the two together](http://avro.apache.org/docs/current/spec.html#Names) to get the fully qualified name to look for — unless the unqualified name is one of the primitive types, in which case it should stay unqualified.