### PR TITLE
fix issue resolving ints and longs in unions

### DIFF
--- a/fastavro/reader.py
+++ b/fastavro/reader.py
@@ -54,6 +54,10 @@ def read_boolean(fo, schema):
     return ord(fo.read(1)) == 49
 
 
+def read_int(fo, schema):
+    return int(read_long(fo, schema))
+
+
 def read_long(fo, schema):
     '''int and long values are written using variable-length, zig-zag
     coding.'''
@@ -72,7 +76,7 @@ def read_long(fo, schema):
         n |= (b & 0x7F) << shift
         shift += 7
 
-    return (n >> 1) ^ -(n & 1)
+    return long((n >> 1) ^ -(n & 1))
 
 
 def read_float(fo, schema):
@@ -216,7 +220,7 @@ READERS = {
     'null': read_null,
     'boolean': read_boolean,
     'string': read_utf8,
-    'int': read_long,
+    'int': read_int,
     'long': read_long,
     'float': read_float,
     'double': read_double,

--- a/fastavro/writer.py
+++ b/fastavro/writer.py
@@ -160,7 +160,7 @@ def validate(datum, schema):
 
     if record_type == 'int':
         return (
-            isinstance(datum, (int, long,))
+            isinstance(datum, (int,))
             and INT_MIN_VALUE <= datum <= INT_MAX_VALUE
         )
 

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -174,3 +174,24 @@ def test_acquaint_schema_accepts_nested_records_from_arrays():
         "type": "record"
     })
     assert 'Nested' in fastavro._writer.SCHEMA_DEFS
+
+
+def test_int_and_long_unions():
+    schema = {
+        "type": "record",
+        "name": "LongTest",
+        "namespace": "test",
+        "fields": [{
+            "name": "field",
+            "type": [{"type": "int"}, {"type": "long"}]
+        }]
+    }
+    records = [{"field": long(123)}]
+    fo = MemoryIO()
+    fastavro.writer(fo, schema, records)
+
+    fo.seek(0)
+    reader = fastavro.reader(fo)
+    new_records = list(reader)
+
+    assert type(new_records[0]['field']) == type(records[0]['field'])


### PR DESCRIPTION
Last one for the time being, but this one is divergent from the official avro library handling (which has the same problem) so you can choose to do with it what you will (but I plan to keep it in my version either way).

Assume you have a field in a schema that is a union between an int and a long. If you have a container where that field was 123L and encoded as a long, when it gets deserialized and re-serialized by the Python code, it will now be encoded as an int. This isn't really a problem when you only have python users, but issues can (and have for us) come up when the other endpoint is something like Java. What happens is that Java properly encodes the value as a long, but when it roundtrips through the python code it comes back to Java encoded as an int. The same comment was made at the end of this message in the mailing list: http://mail-archives.apache.org/mod_mbox/avro-user/201304.mbox/%3cCA+i_aEkzOdL1d6WvZAPbm5VmrgD_8UE-8HC25Rf7WagijjJiMA@mail.gmail.com%3e