### PR TITLE
write the default value if the record has one

### DIFF
--- a/fastavro/writer.py
+++ b/fastavro/writer.py
@@ -235,7 +235,9 @@ def write_record(fo, datum, schema):
     concatenation of the encodings of its fields.  Field values are encoded per
     their schema."""
     for field in schema['fields']:
-        write_data(fo, datum.get(field['name']), field['type'])
+        write_data(fo,
+                   datum.get(field['name'], field.get('default')),
+                   field['type'])
 
 
 WRITERS = {

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -192,3 +192,21 @@ def test_schemaless_writer_and_reader():
     new_file.seek(0)
     new_record = fastavro.schemaless_reader(new_file, schema)
     assert record == new_record
+
+
+def test_default_values():
+    schema = {
+        "type": "record",
+        "fields": [{
+            "name": "default_field",
+            "type": "string",
+            "default": "default_value"
+        }]
+    }
+    new_file = MemoryIO()
+    records = [{}]
+    fastavro.writer(new_file, schema, records)
+    new_file.seek(0)
+    new_reader = fastavro.reader(new_file)
+    new_records = list(new_reader)
+    assert new_records == [{"default_field": "default_value"}]


### PR DESCRIPTION
If a field has a default value it's nice to have the writer go ahead and use that value when serializing (instead of throwing an error about the field missing).