### PR TITLE
correct boolean roundtrip

### DIFF
--- a/fastavro/reader.py
+++ b/fastavro/reader.py
@@ -54,7 +54,7 @@ def read_boolean(fo, schema):
 
     # technically 0x01 == true and 0x00 == false, but many languages will cast
     # anything other than 0 to True and only 0 to False
-    return fo.read(1) != 0x00
+    return unpack('B', fo.read(1))[0] != 0
 
 
 def read_long(fo, schema):

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -192,3 +192,26 @@ def test_schemaless_writer_and_reader():
     new_file.seek(0)
     new_record = fastavro.schemaless_reader(new_file, schema)
     assert record == new_record
+
+
+def test_boolean_roundtrip():
+    schema = {
+        "type": "record",
+        "fields": [{
+            "name": "field",
+            "type": "boolean"
+        }]
+    }
+    record = {"field": True}
+    new_file = MemoryIO()
+    fastavro.schemaless_writer(new_file, schema, record)
+    new_file.seek(0)
+    new_record = fastavro.schemaless_reader(new_file, schema)
+    assert record == new_record
+
+    record = {"field": False}
+    new_file = MemoryIO()
+    fastavro.schemaless_writer(new_file, schema, record)
+    new_file.seek(0)
+    new_record = fastavro.schemaless_reader(new_file, schema)
+    assert record == new_record


### PR DESCRIPTION
Hopefully no more boolean PRs... the previous PR was setting all booleans to True. Copying the associated test case and running it on master shows that.

Previously:

```python
In [22]: pack('B', 1) != 0x00
Out[22]: True

In [23]: pack('B', 0) != 0x00
Out[23]: True
```

Now:

```python
In [25]: unpack('B', pack('B', 1))[0] != 0
Out[25]: True

In [26]: unpack('B', pack('B', 0))[0] != 0
Out[26]: False
```