### PR TITLE
Fix writer.validate to look for bytes rather than str for a fixed or bytes field, ensuring it works with python 3

### DIFF
--- a/fastavro/writer.py
+++ b/fastavro/writer.py
@@ -156,7 +156,7 @@ def validate(datum, schema):
         return is_str(datum)
 
     if record_type == 'bytes':
-        return isinstance(datum, str)
+        return isinstance(datum, bytes)
 
     if record_type == 'int':
         return (
@@ -174,7 +174,7 @@ def validate(datum, schema):
         return isinstance(datum, (int, long, float))
 
     if record_type == 'fixed':
-        return isinstance(datum, str) and len(datum) == schema['size']
+        return isinstance(datum, bytes) and len(datum) == schema['size']
 
     if record_type == 'union':
         return any(validate(datum, s) for s in schema)


### PR DESCRIPTION
In python2 `str is bytes` but in python 3 `str` won't do for fixed/bytes fields (and infact reader decodes as `bytes`)