### PR TITLE
only populate the necessary repo

### DIFF
--- a/fastavro/__init__.py
+++ b/fastavro/__init__.py
@@ -54,13 +54,19 @@ except ImportError as e:
     from . import writer as _writer
     from . import schema as _schema
 
+
+def _acquaint_schema(schema):
+    _reader.acquaint_schema(schema)
+    _writer.acquaint_schema(schema)
+
 reader = iter_avro = _reader.iter_avro
 schemaless_reader = _reader.schemaless_reader
 load = _reader.read_data
 writer = _writer.writer
 schemaless_writer = _writer.schemaless_writer
 dump = _writer.write_data
-acquaint_schema = _schema.acquaint_schema
+acquaint_schema = _acquaint_schema
+_schema.acquaint_schema = _acquaint_schema
 
 __all__ = [
     n for n in locals().keys() if not n.startswith('_')

--- a/fastavro/schema.py
+++ b/fastavro/schema.py
@@ -19,32 +19,6 @@ class UnknownType(Exception):
         self.name = name
 
 
-def acquaint_schema(schema):
-    # TODO: Untangle this recursive dependency
-    try:
-        from ._reader import READERS, read_data
-        from ._writer import SCHEMA_DEFS, WRITERS, write_data
-    except ImportError:
-        from .reader import READERS, read_data
-        from .writer import SCHEMA_DEFS, WRITERS, write_data
-
-    extract_named_schemas_into_repo(
-        schema,
-        READERS,
-        lambda schema: lambda fo, _: read_data(fo, schema),
-    )
-    extract_named_schemas_into_repo(
-        schema,
-        WRITERS,
-        lambda schema: lambda fo, datum, _: write_data(fo, datum, schema),
-    )
-    extract_named_schemas_into_repo(
-        schema,
-        SCHEMA_DEFS,
-        lambda schema: schema,
-    )
-
-
 def extract_record_type(schema):
     if isinstance(schema, dict):
         return schema['type']

--- a/fastavro/writer.py
+++ b/fastavro/writer.py
@@ -9,11 +9,11 @@
 try:
     from ._six import utob, MemoryIO, long, is_str, iteritems
     from ._reader import HEADER_SCHEMA, SYNC_SIZE, MAGIC
-    from ._schema import acquaint_schema, extract_record_type
+    from ._schema import extract_named_schemas_into_repo, extract_record_type
 except ImportError:
     from .six import utob, MemoryIO, long, is_str, iteritems
     from .reader import HEADER_SCHEMA, SYNC_SIZE, MAGIC
-    from .schema import acquaint_schema, extract_record_type
+    from .schema import extract_named_schemas_into_repo, extract_record_type
 
 try:
     import simplejson as json
@@ -322,6 +322,19 @@ try:
     BLOCK_WRITERS['snappy'] = snappy_write_block
 except ImportError:
     pass
+
+
+def acquaint_schema(schema, repo=WRITERS):
+    extract_named_schemas_into_repo(
+        schema,
+        repo,
+        lambda schema: lambda fo, datum, _: write_data(fo, datum, schema),
+    )
+    extract_named_schemas_into_repo(
+        schema,
+        SCHEMA_DEFS,
+        lambda schema: schema,
+    )
 
 
 def writer(fo,


### PR DESCRIPTION
Instead of populating both the READERS and WRITERS repo on any operation, only the relevant repo will be populated. For a very complex schema I noticed a 5-10% speed up in writing and a 10-20% speed up in reading.