### PR TITLE
always overwrite repo values

### DIFF
--- a/fastavro/schema.py
+++ b/fastavro/schema.py
@@ -67,7 +67,7 @@ def extract_named_schemas_into_repo(schema, repo, transformer, parent_ns=None):
 
     namespace, name = schema_name(schema, parent_ns)
 
-    if name and (name not in repo):
+    if name:
         repo[name] = transformer(schema)
 
     schema_type = schema.get('type')


### PR DESCRIPTION
If a record name was already defined in the repo it would not be overwritten by a new record which would cause reads/writes to potentially fail (since they would use the original schema added to the repo)