### PR TITLE
Add a fixed-size integer type extension and path-based error handling

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-11-04 version 0.10.0
+    * Add error path-based reporting of parsing errors
+    * Add option support for an extension providing fixed sized
+      integers via specially named fixed types.
+
 2015-10-14 version 0.9.6
     * Support streaming IO (@mjwillson in PR #40)
 
@@ -9,7 +14,7 @@
 
 2015-09-01 version 0.9.3
     * Speedup (@scottbelden in PR #30)
-    * Fix writer.validate on Python 3 (@mjwillson in PR #29) 
+    * Fix writer.validate on Python 3 (@mjwillson in PR #29)
 
 2015-08-25 version 0.9.2
     * allow extra metadata to be used (@scottbelden in PR #28)
@@ -20,7 +25,7 @@
 
 2015-08-20 version 0.9.0
     * Handle error types (@scottbelden in PR #20)
-    * Fix boolean encoding/decoding (@rodcarroll in PR #22) 
+    * Fix boolean encoding/decoding (@rodcarroll in PR #22)
     * Support binary encoder (issue #14, @scottbelden in PR #24)
 
 2015-08-18 version 0.8.8

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,3 +8,4 @@ recursive-include docs *.rst
 recursive-include docs Makefile
 recursive-include tests *.avro
 recursive-include tests *.py
+recursive-include tests *.avsc

--- a/fastavro/__init__.py
+++ b/fastavro/__init__.py
@@ -42,7 +42,7 @@ The only onterface function is iter_avro, example usage::
         writer(out, schema, records)
 '''
 
-__version__ = '0.9.6'
+__version__ = '0.10.0'
 
 
 try:

--- a/fastavro/errors.py
+++ b/fastavro/errors.py
@@ -1,0 +1,24 @@
+from .util import path_string
+
+
+class UnknownType(Exception):
+    def __init__(self, name):
+        super(UnknownType, self).__init__(name)
+        self.name = name
+
+
+class AvroValueError(ValueError):
+    pass
+
+    @classmethod
+    def create(cls, reading_or_writing, path, traceback):
+        message = '\n'.join([
+            "Error encountered %s avro message." % reading_or_writing,
+            "Path was: %s" % path_string(path),
+            "Exception traceback: %s" % traceback
+        ])
+        return cls(message)
+
+
+class SchemaResolutionError(Exception):
+    pass

--- a/fastavro/extension.py
+++ b/fastavro/extension.py
@@ -1,0 +1,15 @@
+# cython: auto_cpdef=True
+
+'''Avro Extensions'''
+
+FIXED_EXTENSIONS = {
+    # name  : (size, pack/unpack fmt string)
+    'int8_t': (1, 'b'),
+    'int16_t': (2, 'h'),
+    'int32_t': (4, 'i'),
+    'int64_t': (8, 'l'),
+    'uint8_t': (1, 'B'),
+    'uint16_t': (2, 'H'),
+    'uint32_t': (4, 'I'),
+    'uint64_t': (8, 'L'),
+}

--- a/fastavro/reader.py
+++ b/fastavro/reader.py
@@ -488,9 +488,9 @@ except ImportError:
 def acquaint_schema(schema,
                     repo=READERS,
                     reader_schema_defs=SCHEMA_DEFS,
-                    enable_enxtensions=False):
+                    enable_extensions=False):
 
-    if enable_enxtensions and 'fixed' in repo:
+    if enable_extensions and 'fixed' in repo:
         repo['fixed'] = read_fixed_extension
 
     extract_named_schemas_into_repo(
@@ -540,7 +540,7 @@ class iter_avro:
             for record in avro:
                 process_record(record)
     '''
-    def __init__(self, fo, reader_schema=None, enable_enxtensions=False):
+    def __init__(self, fo, reader_schema=None, enable_extensions=False):
         self.fo = fo
         try:
             self._header = read_data(fo, HEADER_SCHEMA)
@@ -558,7 +558,7 @@ class iter_avro:
 
         acquaint_schema(self.writer_schema,
                         READERS,
-                        enable_enxtensions=enable_enxtensions)
+                        enable_extensions=enable_extensions)
 
         if reader_schema:
             populate_schema_defs(reader_schema, SCHEMA_DEFS)
@@ -575,8 +575,8 @@ class iter_avro:
         return next(self._records)
 
 
-def schemaless_reader(fo, schema, enable_enxtensions=False):
+def schemaless_reader(fo, schema, enable_extensions=False):
     '''Reads a single record writen using the schemaless_writer
     '''
-    acquaint_schema(schema, READERS, enable_enxtensions=enable_enxtensions)
+    acquaint_schema(schema, READERS, enable_extensions=enable_extensions)
     return read_data(fo, schema)

--- a/fastavro/reader.py
+++ b/fastavro/reader.py
@@ -7,6 +7,7 @@
 # Apache 2.0 license (http://www.apache.org/licenses/LICENSE-2.0)
 
 import json
+import traceback
 from struct import unpack
 from zlib import decompress
 
@@ -59,9 +60,9 @@ AVRO_TYPES = set([
     'error_union'
 ])
 
-
-class SchemaResolutionError(Exception):
-    pass
+from .extension import FIXED_EXTENSIONS
+from .util import push_path, pop_path, tracked_reader
+from .errors import SchemaResolutionError, AvroValueError
 
 
 def match_types(writer_type, reader_type):
@@ -115,12 +116,14 @@ def match_schemas(w_schema, r_schema):
         raise SchemaResolutionError(error_msg)
 
 
-def read_null(fo, writer_schema=None, reader_schema=None):
+@tracked_reader
+def read_null(fo, writer_schema=None, reader_schema=None, path=None):
     '''null is written as zero bytes.'''
     return None
 
 
-def read_boolean(fo, writer_schema=None, reader_schema=None):
+@tracked_reader
+def read_boolean(fo, writer_schema=None, reader_schema=None, path=None):
     '''A boolean is written as a single byte whose value is either 0 (false) or
     1 (true).
     '''
@@ -130,7 +133,8 @@ def read_boolean(fo, writer_schema=None, reader_schema=None):
     return unpack('B', fo.read(1))[0] != 0
 
 
-def read_long(fo, writer_schema=None, reader_schema=None):
+@tracked_reader
+def read_long(fo, writer_schema=None, reader_schema=None, path=None):
     '''int and long values are written using variable-length, zig-zag
     coding.'''
     c = fo.read(1)
@@ -151,7 +155,8 @@ def read_long(fo, writer_schema=None, reader_schema=None):
     return (n >> 1) ^ -(n & 1)
 
 
-def read_float(fo, writer_schema=None, reader_schema=None):
+@tracked_reader
+def read_float(fo, writer_schema=None, reader_schema=None, path=None):
     '''A float is written as 4 bytes.
 
     The float is converted into a 32-bit integer using a method equivalent to
@@ -161,7 +166,8 @@ def read_float(fo, writer_schema=None, reader_schema=None):
     return unpack('<f', fo.read(4))[0]
 
 
-def read_double(fo, writer_schema=None, reader_schema=None):
+@tracked_reader
+def read_double(fo, writer_schema=None, reader_schema=None, path=None):
     '''A double is written as 8 bytes.
 
     The double is converted into a 64-bit integer using a method equivalent to
@@ -170,26 +176,44 @@ def read_double(fo, writer_schema=None, reader_schema=None):
     return unpack('<d', fo.read(8))[0]
 
 
-def read_bytes(fo, writer_schema=None, reader_schema=None):
+@tracked_reader
+def read_bytes(fo, writer_schema=None, reader_schema=None, path=None):
     '''Bytes are encoded as a long followed by that many bytes of data.'''
     size = read_long(fo)
     return fo.read(size)
 
 
-def read_utf8(fo, writer_schema=None, reader_schema=None):
+@tracked_reader
+def read_utf8(fo, writer_schema=None, reader_schema=None, path=None):
     '''A string is encoded as a long followed by that many bytes of UTF-8
     encoded character data.
     '''
     return btou(read_bytes(fo), 'utf-8')
 
 
-def read_fixed(fo, writer_schema, reader_schema=None):
+@tracked_reader
+def read_fixed(fo, writer_schema, reader_schema=None, path=None):
     '''Fixed instances are encoded using the number of bytes declared in the
     schema.'''
+
     return fo.read(writer_schema['size'])
 
 
-def read_enum(fo, writer_schema, reader_schema=None):
+@tracked_reader
+def read_fixed_extension(fo, writer_schema, reader_schema=None, path=None):
+    '''Fixed instances are encoded using the number of bytes declared in the
+    schema. This reader has additional support for unsigned types.'''
+
+    name = writer_schema.get('name')
+    if name in FIXED_EXTENSIONS:
+        size, fmt = FIXED_EXTENSIONS[name]
+        return unpack(fmt, fo.read(size))[0]
+
+    return fo.read(writer_schema['size'])
+
+
+@tracked_reader
+def read_enum(fo, writer_schema, reader_schema=None, path=None):
     '''An enum is encoded by a int, representing the zero-based position of the
     symbol in the schema.
     '''
@@ -201,7 +225,8 @@ def read_enum(fo, writer_schema, reader_schema=None):
     return symbol
 
 
-def read_array(fo, writer_schema, reader_schema=None):
+@tracked_reader
+def read_array(fo, writer_schema, reader_schema=None, path=None):
     '''Arrays are encoded as a series of blocks.
 
     Each block consists of a long count value, followed by that many array
@@ -213,10 +238,11 @@ def read_array(fo, writer_schema, reader_schema=None):
     count in this case is the absolute value of the count written.
     '''
     if reader_schema:
-        item_reader = lambda fo, w_schema, r_schema: read_data(
-            fo, w_schema['items'], r_schema['items'])
+        item_reader = lambda fo, w_schema, r_schema, path: read_data(
+            fo, w_schema['items'], r_schema['items'], path=path)
     else:
-        item_reader = lambda fo, w_schema, _: read_data(fo, w_schema['items'])
+        item_reader = lambda fo, w_schema, _, path: read_data(
+            fo, w_schema['items'], path=path)
     read_items = []
 
     block_count = read_long(fo)
@@ -228,13 +254,18 @@ def read_array(fo, writer_schema, reader_schema=None):
             read_long(fo)
 
         for i in xrange(block_count):
-            read_items.append(item_reader(fo, writer_schema, reader_schema))
+            read_items.append(item_reader(fo,
+                                          writer_schema,
+                                          reader_schema,
+                                          path=push_path(path, i)))
+            pop_path(path)
         block_count = read_long(fo)
 
     return read_items
 
 
-def read_map(fo, writer_schema, reader_schema=None):
+@tracked_reader
+def read_map(fo, writer_schema, reader_schema=None, path=None):
     '''Maps are encoded as a series of blocks.
 
     Each block consists of a long count value, followed by that many key/value
@@ -246,10 +277,12 @@ def read_map(fo, writer_schema, reader_schema=None):
     count in this case is the absolute value of the count written.
     '''
     if reader_schema:
-        item_reader = lambda fo, w_schema, r_schema: read_data(
-            fo, w_schema['values'], r_schema['values'])
+        item_reader = lambda fo, w_schema, r_schema, path: read_data(
+            fo, w_schema['values'], r_schema['values'], path=path)
     else:
-        item_reader = lambda fo, w_schema, _: read_data(fo, w_schema['values'])
+        item_reader = lambda fo, w_schema, _, path: read_data(
+            fo, w_schema['values'], path=path)
+
     read_items = {}
     block_count = read_long(fo)
     while block_count != 0:
@@ -260,13 +293,18 @@ def read_map(fo, writer_schema, reader_schema=None):
 
         for i in xrange(block_count):
             key = read_utf8(fo)
-            read_items[key] = item_reader(fo, writer_schema, reader_schema)
+            read_items[key] = item_reader(fo,
+                                          writer_schema,
+                                          reader_schema,
+                                          path=push_path(path, key))
+            pop_path(path)
         block_count = read_long(fo)
 
     return read_items
 
 
-def read_union(fo, writer_schema, reader_schema=None):
+@tracked_reader
+def read_union(fo, writer_schema, reader_schema=None, path=None):
     '''A union is encoded by first writing a long value indicating the
     zero-based position within the union of the schema of its value.
 
@@ -274,22 +312,33 @@ def read_union(fo, writer_schema, reader_schema=None):
     '''
     # schema resolution
     index = read_long(fo)
+    cur_writer_schema = writer_schema[index]
     if reader_schema:
         # Handle case where the reader schema is just a single type (not union)
         if not isinstance(reader_schema, list):
-            if match_types(writer_schema[index], reader_schema):
-                return read_data(fo, writer_schema[index], reader_schema)
+            if match_types(cur_writer_schema, reader_schema):
+                return read_data(fo, cur_writer_schema, reader_schema)
         else:
             for schema in reader_schema:
-                if match_types(writer_schema[index], schema):
-                    return read_data(fo, writer_schema[index], schema)
+                if match_types(cur_writer_schema, schema):
+                    result = read_data(fo,
+                                       cur_writer_schema,
+                                       schema,
+                                       path=push_path(path, cur_writer_schema))
+                    pop_path(path)
+                    return result
         raise SchemaResolutionError('Schema mismatch: {0} not found in {1}'
                                     .format(writer_schema, reader_schema))
     else:
-        return read_data(fo, writer_schema[index])
+        result = read_data(fo,
+                           cur_writer_schema,
+                           path=push_path(path, cur_writer_schema))
+        pop_path(path)
+        return result
 
 
-def read_record(fo, writer_schema, reader_schema=None):
+@tracked_reader
+def read_record(fo, writer_schema, reader_schema=None, path=None):
     '''A record is encoded by encoding the values of its fields in the order
     that they are declared. In other words, a record is encoded as just the
     concatenation of the encodings of its fields.  Field values are encoded per
@@ -311,15 +360,22 @@ def read_record(fo, writer_schema, reader_schema=None):
     record = {}
     if reader_schema is None:
         for field in writer_schema['fields']:
-            record[field['name']] = read_data(fo, field['type'])
+            name = field['name']
+            record[name] = read_data(fo,
+                                     field['type'],
+                                     path=push_path(path, name))
+            pop_path(path)
     else:
         readers_field_dict = {f['name']: f for f in reader_schema['fields']}
         for field in writer_schema['fields']:
             readers_field = readers_field_dict.get(field['name'])
             if readers_field:
-                record[field['name']] = read_data(fo,
-                                                  field['type'],
-                                                  readers_field['type'])
+                name = field['name']
+                record[name] = read_data(fo,
+                                         field['type'],
+                                         readers_field['type'],
+                                         path=push_path(path, name))
+                pop_path(path)
             else:
                 # should implement skip
                 read_data(fo, field['type'], field['type'])
@@ -371,13 +427,24 @@ SCHEMA_DEFS = {
 }
 
 
-def read_data(fo, writer_schema, reader_schema=None):
+def read_data(fo, writer_schema, reader_schema=None, path=None):
     '''Read data from file object according to schema.'''
+    if path is None:
+        path = []
 
     record_type = extract_record_type(writer_schema)
     if reader_schema and record_type in AVRO_TYPES:
         match_schemas(writer_schema, reader_schema)
-    return READERS[record_type](fo, writer_schema, reader_schema)
+    try:
+        reader = READERS[record_type]
+        return reader(fo, writer_schema, reader_schema, path)
+    except SchemaResolutionError:
+        raise
+    except AvroValueError:
+        raise
+    except Exception:
+        tb = traceback.format_exc()
+        raise AvroValueError.create('reading', path, tb)
 
 
 def skip_sync(fo, sync_marker):
@@ -420,12 +487,17 @@ except ImportError:
 
 def acquaint_schema(schema,
                     repo=READERS,
-                    reader_schema_defs=SCHEMA_DEFS):
+                    reader_schema_defs=SCHEMA_DEFS,
+                    enable_enxtensions=False):
+
+    if enable_enxtensions and 'fixed' in repo:
+        repo['fixed'] = read_fixed_extension
+
     extract_named_schemas_into_repo(
         schema,
         repo,
-        lambda schema: lambda fo, _, r_schema: read_data(
-            fo, schema, reader_schema_defs.get(r_schema)),
+        lambda schema: lambda fo, _, r_schema, path: read_data(
+            fo, schema, reader_schema_defs.get(r_schema), path),
     )
 
 
@@ -468,7 +540,7 @@ class iter_avro:
             for record in avro:
                 process_record(record)
     '''
-    def __init__(self, fo, reader_schema=None):
+    def __init__(self, fo, reader_schema=None, enable_enxtensions=False):
         self.fo = fo
         try:
             self._header = read_data(fo, HEADER_SCHEMA)
@@ -484,7 +556,10 @@ class iter_avro:
         self.codec = self.metadata.get('avro.codec', 'null')
         self.reader_schema = reader_schema
 
-        acquaint_schema(self.writer_schema, READERS)
+        acquaint_schema(self.writer_schema,
+                        READERS,
+                        enable_enxtensions=enable_enxtensions)
+
         if reader_schema:
             populate_schema_defs(reader_schema, SCHEMA_DEFS)
         self._records = _iter_avro(fo,
@@ -500,8 +575,8 @@ class iter_avro:
         return next(self._records)
 
 
-def schemaless_reader(fo, schema):
+def schemaless_reader(fo, schema, enable_enxtensions=False):
     '''Reads a single record writen using the schemaless_writer
     '''
-    acquaint_schema(schema, READERS)
+    acquaint_schema(schema, READERS, enable_enxtensions=enable_enxtensions)
     return read_data(fo, schema)

--- a/fastavro/schema.py
+++ b/fastavro/schema.py
@@ -13,10 +13,7 @@ PRIMITIVES = set([
 ])
 
 
-class UnknownType(Exception):
-    def __init__(self, name):
-        super(UnknownType, self).__init__(name)
-        self.name = name
+from .errors import UnknownType
 
 
 def extract_record_type(schema):

--- a/fastavro/util.py
+++ b/fastavro/util.py
@@ -1,0 +1,66 @@
+# cython: auto_cpdef=True
+'''Utility functions'''
+
+from functools import wraps
+
+
+def push_path(path, name):
+    if path is None:
+        return [name]
+    else:
+        path.append(name)
+        return path
+
+
+def pop_path(path):
+    if path is None:
+        return None
+    else:
+        path.pop()
+        return path
+
+
+def path_string(path):
+    def format_item(item):
+        if isinstance(item, (int, long)):
+            return "[%s]" % str(item)
+        else:
+            return str(item)
+
+    if path is None:
+        return ''
+    else:
+        return '.'.join(format_item(item) for item in path)
+
+
+def _get_type_symbol(func):
+    name_parts = func.__name__.split('_')
+    type_name = '_'.join(name_parts[1:])
+    type_symbol = '<' + type_name + '>'
+    return type_symbol
+
+
+def tracked_writer(f):
+    type_symbol = _get_type_symbol(f)
+
+    @wraps(f)
+    def wrapper(fo, datum, schema=None, path=None):
+        path = push_path(path, type_symbol)
+        result = f(fo, datum, schema, path)
+        pop_path(path)
+        return result
+
+    return wrapper
+
+
+def tracked_reader(f):
+    type_symbol = _get_type_symbol(f)
+
+    @wraps(f)
+    def wrapper(fo, writer_schema=None, reader_schema=None, path=None):
+        path = push_path(path, type_symbol)
+        result = f(fo, writer_schema, reader_schema, path)
+        pop_path(path)
+        return result
+
+    return wrapper

--- a/fastavro/util.py
+++ b/fastavro/util.py
@@ -1,7 +1,13 @@
 # cython: auto_cpdef=True
 '''Utility functions'''
 
+import sys
 from functools import wraps
+
+if sys.version_info < (3,):
+    INTEGER_TYPES = (int, long,)  # flake8: noqa
+else:
+    INTEGER_TYPES = (int,)
 
 
 def push_path(path, name):
@@ -22,7 +28,7 @@ def pop_path(path):
 
 def path_string(path):
     def format_item(item):
-        if isinstance(item, (int, long)):
+        if isinstance(item, INTEGER_TYPES):
             return "[%s]" % str(item)
         else:
             return str(item)

--- a/fastavro/writer.py
+++ b/fastavro/writer.py
@@ -20,6 +20,7 @@ try:
 except ImportError:
     import json
 
+import traceback
 from binascii import crc32
 from collections import Iterable, Mapping
 from os import urandom, SEEK_SET
@@ -28,19 +29,23 @@ from zlib import compress
 
 NoneType = type(None)
 
+from .extension import FIXED_EXTENSIONS
+from .util import push_path, pop_path, tracked_writer
+from .errors import AvroValueError
 
-def write_null(fo, datum, schema=None):
+
+def write_null(fo, datum, schema=None, path=None):
     '''null is written as zero bytes'''
     pass
 
 
-def write_boolean(fo, datum, schema=None):
+def write_boolean(fo, datum, schema=None, path=None):
     '''A boolean is written as a single byte whose value is either 0 (false) or
     1 (true).'''
     fo.write(pack('B', 1 if datum else 0))
 
 
-def write_int(fo, datum, schema=None):
+def write_int(fo, datum, schema=None, path=None):
     '''int and long values are written using variable-length, zig-zag coding.
     '''
     datum = (datum << 1) ^ (datum >> 63)
@@ -52,27 +57,31 @@ def write_int(fo, datum, schema=None):
 write_long = write_int
 
 
-def write_float(fo, datum, schema=None):
+@tracked_writer
+def write_float(fo, datum, schema=None, path=None):
     '''A float is written as 4 bytes.  The float is converted into a 32-bit
     integer using a method equivalent to Java's floatToIntBits and then encoded
     in little-endian format.'''
     fo.write(pack('<f', datum))
 
 
-def write_double(fo, datum, schema=None):
+@tracked_writer
+def write_double(fo, datum, schema=None, path=None):
     '''A double is written as 8 bytes.  The double is converted into a 64-bit
     integer using a method equivalent to Java's doubleToLongBits and then
     encoded in little-endian format.  '''
     fo.write(pack('<d', datum))
 
 
-def write_bytes(fo, datum, schema=None):
+@tracked_writer
+def write_bytes(fo, datum, schema=None, path=None):
     '''Bytes are encoded as a long followed by that many bytes of data.'''
     write_long(fo, len(datum))
     fo.write(datum)
 
 
-def write_utf8(fo, datum, schema=None):
+@tracked_writer
+def write_utf8(fo, datum, schema=None, path=None):
     '''A string is encoded as a long followed by that many bytes of UTF-8
     encoded character data.'''
     write_bytes(fo, utob(datum))
@@ -84,20 +93,35 @@ def write_crc32(fo, bytes):
     fo.write(pack('>I', data))
 
 
-def write_fixed(fo, datum, schema=None):
+@tracked_writer
+def write_fixed(fo, datum, schema=None, path=None):
     '''Fixed instances are encoded using the number of bytes declared in the
     schema.'''
     fo.write(datum)
 
 
-def write_enum(fo, datum, schema):
+@tracked_writer
+def write_fixed_extension(fo, datum, schema=None, path=None):
+    '''Fixed instances are encoded using the number of bytes declared in the
+    schema.'''
+    if schema is not None and schema.get('name') in FIXED_EXTENSIONS:
+        _, pack_format = FIXED_EXTENSIONS[schema['name']]
+        fo.write(pack(pack_format, datum))
+    else:
+        fo.write(datum)
+
+
+@tracked_writer
+def write_enum(fo, datum, schema, path):
     """An enum is encoded by a int, representing the zero-based position of
     the symbol in the schema."""
     index = schema['symbols'].index(datum)
-    write_int(fo, index)
+    write_int(fo, index, path=push_path(path, datum))
+    pop_path(path)
 
 
-def write_array(fo, datum, schema):
+@tracked_writer
+def write_array(fo, datum, schema, path):
     """Arrays are encoded as a series of blocks.
 
     Each block consists of a long count value, followed by that many array
@@ -111,12 +135,14 @@ def write_array(fo, datum, schema):
     if len(datum) > 0:
         write_long(fo, len(datum))
         dtype = schema['items']
-        for item in datum:
-            write_data(fo, item, dtype)
+        for i, item in enumerate(datum):
+            write_data(fo, item, dtype, path=push_path(path, i))
+            pop_path(path)
     write_long(fo, 0)
 
 
-def write_map(fo, datum, schema):
+@tracked_writer
+def write_map(fo, datum, schema, path):
     """Maps are encoded as a series of blocks.
 
     Each block consists of a long count value, followed by that many key/value
@@ -130,8 +156,11 @@ def write_map(fo, datum, schema):
         write_long(fo, len(datum))
         vtype = schema['values']
         for key, val in iteritems(datum):
-            write_utf8(fo, key)
-            write_data(fo, val, vtype)
+            write_utf8(fo, key, path=push_path(path, 'KEY'))
+            pop_path(path)
+            write_data(fo, val, vtype, path=push_path(path, key))
+            pop_path(path)
+
     write_long(fo, 0)
 
 
@@ -211,7 +240,8 @@ def validate(datum, schema):
     raise ValueError("I don't know what a {0} is.".format(record_type))
 
 
-def write_union(fo, datum, schema):
+@tracked_writer
+def write_union(fo, datum, schema, path=None):
     """A union is encoded by first writing a long value indicating the
     zero-based position within the union of the schema of its value. The value
     is then encoded per the indicated schema within the union."""
@@ -226,10 +256,12 @@ def write_union(fo, datum, schema):
 
     # write data
     write_long(fo, index)
-    write_data(fo, datum, schema[index])
+    write_data(fo, datum, schema[index], path=push_path(path, schema[index]))
+    pop_path(path)
 
 
-def write_record(fo, datum, schema):
+@tracked_writer
+def write_record(fo, datum, schema, path=None):
     """A record is encoded by encoding the values of its fields in the order
     that they are declared. In other words, a record is encoded as just the
     concatenation of the encodings of its fields.  Field values are encoded per
@@ -237,7 +269,9 @@ def write_record(fo, datum, schema):
     for field in schema['fields']:
         write_data(fo,
                    datum.get(field['name'], field.get('default')),
-                   field['type'])
+                   field['type'],
+                   path=push_path(path, field['name']))
+        pop_path(path)
 
 
 WRITERS = {
@@ -273,8 +307,17 @@ _base_types = [
 SCHEMA_DEFS = {typ: typ for typ in _base_types}
 
 
-def write_data(fo, datum, schema):
-    return WRITERS[extract_record_type(schema)](fo, datum, schema)
+def write_data(fo, datum, schema, path=None):
+    if path is None:
+        path = []
+
+    try:
+        return WRITERS[extract_record_type(schema)](fo, datum, schema, path)
+    except AvroValueError:
+        raise
+    except Exception:
+        tb = traceback.format_exc()
+        raise AvroValueError.create('writing', path, tb)
 
 
 def write_header(fo, metadata, sync_marker):
@@ -283,7 +326,7 @@ def write_header(fo, metadata, sync_marker):
         'meta': {key: utob(value) for key, value in iteritems(metadata)},
         'sync': sync_marker
     }
-    write_data(fo, header, HEADER_SCHEMA)
+    write_data(fo, header, HEADER_SCHEMA, path=['HEADER'])
 
 
 def null_write_block(fo, block_bytes):
@@ -324,11 +367,15 @@ except ImportError:
     pass
 
 
-def acquaint_schema(schema, repo=WRITERS):
+def acquaint_schema(schema, repo=WRITERS, enable_extensions=False):
+    if enable_extensions and 'fixed' in repo:
+        repo['fixed'] = write_fixed_extension
+
     extract_named_schemas_into_repo(
         schema,
         repo,
-        lambda schema: lambda fo, datum, _: write_data(fo, datum, schema),
+        lambda schema: lambda fo, datum, _, path:
+            write_data(fo, datum, schema, path=path),
     )
     extract_named_schemas_into_repo(
         schema,
@@ -342,7 +389,8 @@ def writer(fo,
            records,
            codec='null',
            sync_interval=1000 * SYNC_SIZE,
-           metadata=None):
+           metadata=None,
+           enable_extensions=False):
     sync_marker = urandom(SYNC_SIZE)
     io = MemoryIO()
     block_count = 0
@@ -363,7 +411,7 @@ def writer(fo,
         io.seek(0, SEEK_SET)
 
     write_header(fo, metadata, sync_marker)
-    acquaint_schema(schema)
+    acquaint_schema(schema, enable_extensions=enable_extensions)
 
     for record in records:
         write_data(io, record, schema)
@@ -378,8 +426,8 @@ def writer(fo,
     fo.flush()
 
 
-def schemaless_writer(fo, schema, record):
+def schemaless_writer(fo, schema, record, enable_extensions=False):
     '''Write a single record without the schema or header information
     '''
-    acquaint_schema(schema)
+    acquaint_schema(schema, enable_extensions=enable_extensions)
     write_data(fo, record, schema)

--- a/tests/avro-files/complex-nested.avsc
+++ b/tests/avro-files/complex-nested.avsc
@@ -1,0 +1,43 @@
+{
+      "type": "record",
+      "name": "top_level",
+      "doc": "Complex test for avro with extensions",
+      "fields": [
+        {"name": "test_boolean", "type": "boolean"},
+        {"name": "test_int", "type": "int"},
+        {"name": "test_long", "type": "long"},
+        {"name": "test_float", "type": "float"},
+        {"name": "test_double", "type": "double"},
+        {"name": "test_bytes", "type": "bytes"},
+        {"name": "test_string", "type": "string"},
+        {
+          "name": "second_level",
+          "type":
+            {"type": "record", "name": "second_level_rec",
+              "fields": [
+              {"name": "test_int2", "type": "int"},
+              {"name": "test_string2", "type": "string"},
+              {
+                "name": "default_level",
+                "type":
+                  {"type": "record", "name": "default_level_rec",
+                    "fields": [
+                      {"name": "test_int_def", "type": "int", "default": 5},
+                      {"name": "test_string_def", "type": "string", "default": "H3l!0 W05Ld"}
+                    ]
+                  }
+                }
+              ]
+            }
+        },
+        {"name": "fixed_int8",  "type": {"type": "fixed", "name": "int8_t", "size": 1}},
+        {"name": "fixed_int16", "type": {"type": "fixed", "name": "int16_t", "size": 2}},
+        {"name": "fixed_int32", "type": {"type": "fixed", "name": "int32_t", "size": 4}},
+        {"name": "fixed_int64", "type": {"type": "fixed", "name": "int64_t", "size": 8}},
+        {"name": "fixed_uint8",  "type": {"type": "fixed", "name": "uint8_t", "size": 1}},
+        {"name": "fixed_uint16", "type": {"type": "fixed", "name": "uint16_t", "size": 2}},
+        {"name": "fixed_uint32", "type": {"type": "fixed", "name": "uint32_t", "size": 4}},
+        {"name": "fixed_uint64", "type": {"type": "fixed", "name": "uint64_t", "size": 8}},
+        {"name": "fixed_int8_2", "type": "int8_t"}
+      ]
+    }

--- a/tests/test_avro_errors.py
+++ b/tests/test_avro_errors.py
@@ -1,0 +1,220 @@
+from fastavro.reader import read_data
+from fastavro.writer import write_data
+
+from fastavro.six import MemoryIO
+from fastavro.errors import AvroValueError
+
+
+def test_fastavro_errors_write_record():
+    fo = MemoryIO()
+
+    schema = {
+        "type": "record",
+        "name": "extension_test",
+        "doc": "Complex schema with avro extensions",
+        "fields": [
+            {"name": "x",
+             "type": {
+                "type": "record",
+                "name": "inner",
+                "fields": [
+                    {"name": "y", "type": "int"}
+                ]
+             }}
+        ]
+    }
+
+    given = {"x": {"y": "hello, world"}}
+    try:
+        write_data(fo, given, schema)
+        assert False, 'bad schema did not raise exception!'
+    except AvroValueError as e:
+        assert "<record>.x.<record>.y" in str(e)
+
+
+def test_fastavro_errors_read_record():
+    fo = MemoryIO()
+
+    writer_schema = {
+        "type": "record",
+        "name": "extension_test",
+        "doc": "Complex schema with avro extensions",
+        "fields": [
+            {"name": "x",
+             "type": {
+                "type": "record",
+                "name": "inner",
+                "fields": [
+                    {"name": "y", "type": "int"}
+                ]
+             }}
+        ]
+    }
+
+    reader_schema = {
+        "type": "record",
+        "name": "extension_test",
+        "doc": "Complex schema with avro extensions",
+        "fields": [
+            {"name": "x",
+             "type": {
+                "type": "record",
+                "name": "inner",
+                "fields": [
+                    {"name": "y", "type": "float"}
+                ]
+             }}
+        ]
+    }
+
+    given = {"x": {"y": 0}}
+
+    write_data(fo, given, writer_schema)
+    fo.seek(0)
+    try:
+        read_data(fo, reader_schema)
+        assert False, 'bad schema did not raise!'
+    except AvroValueError as e:
+        assert '<record>.x.<record>.y' in str(e)
+
+
+def test_fastavro_errors_write_map():
+    fo = MemoryIO()
+
+    schema = {
+        "type": "map",
+        "values": "float"
+    }
+
+    given = {"x": "asdf"}
+
+    try:
+        write_data(fo, given, schema)
+        assert False, 'bad schema did not raise!'
+    except AvroValueError as e:
+        assert '<map>.x' in str(e)
+
+
+def test_fastavro_errors_read_map():
+    fo = MemoryIO()
+
+    writer_schema = {
+        "type": "map",
+        "values": "float"
+    }
+
+    reader_schema = {
+        "type": "map",
+        "values": "double"
+    }
+
+    given = {"x": 0}
+
+    write_data(fo, given, writer_schema)
+    fo.seek(0)
+    try:
+        read_data(fo, reader_schema)
+        assert False, 'bad schema did not raise!'
+    except AvroValueError as e:
+        assert '<map>.x.<double>' in str(e)
+
+
+def test_fastavro_errors_write_enum():
+    fo = MemoryIO()
+
+    schema = {
+        "type": "enum",
+        "name": "Suit",
+        "symbols": [
+            "SPADES",
+            "HEARTS",
+            "DIAMONDS",
+            "CLUBS",
+        ]
+    }
+
+    given = "POTS"
+
+    try:
+        write_data(fo, given, schema)
+        assert False, 'bad schema did not raise!'
+    except AvroValueError as e:
+        assert '<enum>' in str(e)
+
+
+def test_fastavro_errors_read_enum():
+    fo = MemoryIO()
+
+    writer_schema = {
+        "type": "enum",
+        "name": "Suit",
+        "symbols": [
+            "SPADES",
+            "HEARTS",
+            "DIAMONDS",
+            "CLUBS",
+        ]
+    }
+
+    reader_schema = {
+        "type": "enum",
+        "name": "Suit",
+        "symbols": [
+            "SPADES",
+            "HEARTS",
+            "DIAMONDS",
+        ]
+    }
+
+    given = "CLUBS"
+
+    write_data(fo, given, writer_schema)
+    fo.seek(0)
+    try:
+        read_data(fo, reader_schema)
+        assert False, 'bad schema did not raise!'
+    except AvroValueError as e:
+        assert '<enum>' in str(e)
+
+
+def test_fastavro_errors_write_array():
+    fo = MemoryIO()
+
+    schema = {
+        "type": "array",
+        "items": "int",
+    }
+
+    given = [0, "hello"]
+
+    try:
+        write_data(fo, given, schema)
+        assert False, 'bad schema did not raise!'
+    except AvroValueError as e:
+        assert '<array>.[1]' in str(e)
+
+
+def test_fastavro_errors_read_array():
+    fo = MemoryIO()
+
+    writer_schema = {
+        "type": "array",
+        "items": "int",
+    }
+
+    reader_schema = {
+        "type": "array",
+        "items": "float",
+    }
+
+    given = [10, 20, 30]
+
+    write_data(fo, given, writer_schema)
+    fo.seek(0)
+    try:
+        read_data(fo, reader_schema)
+        assert False, 'bad schema did not raise!'
+    except AvroValueError as e:
+        # .[1] because the first element is read succesfully
+        # (but would be corrupt)
+        assert '<array>.[1].<float>' in str(e)

--- a/tests/test_fastavro_extensions.py
+++ b/tests/test_fastavro_extensions.py
@@ -62,7 +62,7 @@ def test_fastavro_extensions():
     fastavro.writer(fo, schema, records, enable_extensions=True)
 
     fo.seek(0)
-    new_reader = fastavro.reader(fo, enable_enxtensions=True)
+    new_reader = fastavro.reader(fo, enable_extensions=True)
 
     assert new_reader.schema == schema
 
@@ -105,7 +105,7 @@ def test_fastavro_complex_nested():
     fastavro.writer(fo, schema, records, enable_extensions=True)
 
     fo.seek(0)
-    new_reader = fastavro.reader(fo, enable_enxtensions=True)
+    new_reader = fastavro.reader(fo, enable_extensions=True)
 
     assert new_reader.schema == schema
 

--- a/tests/test_fastavro_extensions.py
+++ b/tests/test_fastavro_extensions.py
@@ -81,7 +81,7 @@ def test_fastavro_complex_nested():
         "test_long": 20,
         "test_float": 2.0,
         "test_double": 2.0,
-        "test_bytes": 'asdf',
+        "test_bytes": b'asdf',
         "test_string": 'qwerty',
         "second_level": {
             "test_int2": 100,

--- a/tests/test_fastavro_extensions.py
+++ b/tests/test_fastavro_extensions.py
@@ -1,0 +1,113 @@
+import json
+from os.path import join, abspath, dirname
+
+import fastavro
+from fastavro.six import MemoryIO
+
+data_dir = join(abspath(dirname(__file__)), 'avro-files')
+
+
+def test_fastavro_extensions():
+    fo = MemoryIO()
+
+    schema = {
+        "type": "record",
+        "name": "extension_test",
+        "doc": "Complex schema with avro extensions",
+        "fields": [
+            {"name": "fixed_int8",  "type":
+                {"type": "fixed", "name": "int8_t", "size": 1}},
+            {"name": "fixed_int16", "type":
+                {"type": "fixed", "name": "int16_t", "size": 2}},
+            {"name": "fixed_int32", "type":
+                {"type": "fixed", "name": "int32_t", "size": 4}},
+            {"name": "fixed_int64", "type":
+                {"type": "fixed", "name": "int64_t", "size": 8}},
+            {"name": "fixed_uint8",  "type":
+                {"type": "fixed", "name": "uint8_t", "size": 1}},
+            {"name": "fixed_uint16", "type":
+                {"type": "fixed", "name": "uint16_t", "size": 2}},
+            {"name": "fixed_uint32", "type":
+                {"type": "fixed", "name": "uint32_t", "size": 4}},
+            {"name": "fixed_uint64", "type":
+                {"type": "fixed", "name": "uint64_t", "size": 8}},
+            {"name": "fixed_uint64_2", "type": "uint64_t"},
+        ]
+    }
+
+    records = [
+        {
+            "fixed_int8": 127,
+            "fixed_int16": -32768,
+            "fixed_int32": 2147483647,
+            "fixed_int64": 9223372036854775807,
+            "fixed_uint8": 2**8 - 1,
+            "fixed_uint16": 2**16 - 1,
+            "fixed_uint32": 2**32 - 1,
+            "fixed_uint64": 2**64 - 1,
+            "fixed_uint64_2": 0,
+        }, {
+            "fixed_int8": 1,
+            "fixed_int16": -2,
+            "fixed_int32": 3,
+            "fixed_int64": -4,
+            "fixed_uint8": 10,
+            "fixed_uint16": 20,
+            "fixed_uint32": 30,
+            "fixed_uint64": 40,
+            "fixed_uint64_2": 1000,
+        }
+    ]
+
+    fastavro.writer(fo, schema, records, enable_extensions=True)
+
+    fo.seek(0)
+    new_reader = fastavro.reader(fo, enable_enxtensions=True)
+
+    assert new_reader.schema == schema
+
+    new_records = list(new_reader)
+    assert new_records == records
+
+
+def test_fastavro_complex_nested():
+    fo = MemoryIO()
+    with open(join(data_dir, 'complex-nested.avsc')) as f:
+        schema = json.load(f)
+
+    records = [{
+        "test_boolean": True,
+        "test_int": 10,
+        "test_long": 20,
+        "test_float": 2.0,
+        "test_double": 2.0,
+        "test_bytes": 'asdf',
+        "test_string": 'qwerty',
+        "second_level": {
+            "test_int2": 100,
+            "test_string2": "asdf",
+            "default_level": {
+                "test_int_def": 1,
+                "test_string_def": "nope",
+            }
+        },
+        "fixed_int8": 1,
+        "fixed_int16": 2,
+        "fixed_int32": 3,
+        "fixed_int64": 4,
+        "fixed_uint8": 1,
+        "fixed_uint16": 2,
+        "fixed_uint32": 3,
+        "fixed_uint64": 4,
+        "fixed_int8_2": 12,
+    }]
+
+    fastavro.writer(fo, schema, records, enable_extensions=True)
+
+    fo.seek(0)
+    new_reader = fastavro.reader(fo, enable_enxtensions=True)
+
+    assert new_reader.schema == schema
+
+    new_records = list(new_reader)
+    assert new_records == records


### PR DESCRIPTION
This adds two new features that my organization required.
#### Extension for fixed-size integer types

When enabled via the enable_extensions argument to reader/writer, fastavro will now treat fixed types that have names matching the fixed integer types (uint8_t through uint64_t and int8_t through int64_t) as integers. We work with networking devices, where fixed size integers are important.
#### Path-based error reporting

Fastavro now tracks it's position as it traverses a record so that parsing errors provide meaningful error messages. We use fastavro together with a schema registry instead of for reading avro files with an embedded schema, so schema errors are more likely. This feature is critical to help users diagnose where there messages failed to match the expected schema.

Every attempt has been made to follow conventions of other code in the package: tests for these features are provided and flake8 passes. If you wish to pull in one feature and not the other, the commits are relatively isolated; let me know if they need to be isolated further.
