### PR TITLE
adding support for python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ install:
 script:
     - tox
 env:
+    - TOXENV=py26
     - TOXENV=py27
     - TOXENV=py34
     - TOXENV=py35

--- a/fastavro/reader.py
+++ b/fastavro/reader.py
@@ -11,11 +11,13 @@ from struct import unpack
 from zlib import decompress
 
 try:
-    from ._six import MemoryIO, xrange, btou, utob, iteritems
-    from ._schema import extract_named_schemas_into_repo, extract_record_type
+    from fastavro._six import MemoryIO, xrange, btou, utob, iteritems
+    from fastavro._schema import extract_named_schemas_into_repo,\
+        extract_record_type
 except ImportError:
-    from .six import MemoryIO, xrange, btou, utob, iteritems
-    from .schema import extract_named_schemas_into_repo, extract_record_type
+    from fastavro.six import MemoryIO, xrange, btou, utob, iteritems
+    from fastavro.schema import extract_named_schemas_into_repo,\
+        extract_record_type
 
 VERSION = 1
 MAGIC = b'Obj' + utob(chr(VERSION))
@@ -313,7 +315,8 @@ def read_record(fo, writer_schema, reader_schema=None):
         for field in writer_schema['fields']:
             record[field['name']] = read_data(fo, field['type'])
     else:
-        readers_field_dict = {f['name']: f for f in reader_schema['fields']}
+        readers_field_dict = dict([(f['name'], f) for f in
+                                   reader_schema['fields']])
         for field in writer_schema['fields']:
             readers_field = readers_field_dict.get(field['name'])
             if readers_field:
@@ -477,7 +480,7 @@ class iter_avro:
 
         # `meta` values are bytes. So, the actual decoding has to be external.
         self.metadata = \
-            {k: btou(v) for k, v in iteritems(self._header['meta'])}
+            dict([(k, btou(v)) for k, v in iteritems(self._header['meta'])])
 
         self.schema = self.writer_schema = \
             json.loads(self.metadata['avro.schema'])

--- a/fastavro/writer.py
+++ b/fastavro/writer.py
@@ -7,13 +7,15 @@
 # Apache 2.0 license (http://www.apache.org/licenses/LICENSE-2.0)
 
 try:
-    from ._six import utob, MemoryIO, long, is_str, iteritems
-    from ._reader import HEADER_SCHEMA, SYNC_SIZE, MAGIC
-    from ._schema import extract_named_schemas_into_repo, extract_record_type
+    from fastavro._six import utob, MemoryIO, long, is_str, iteritems
+    from fastavro._reader import HEADER_SCHEMA, SYNC_SIZE, MAGIC
+    from fastavro._schema import extract_named_schemas_into_repo,\
+        extract_record_type
 except ImportError:
-    from .six import utob, MemoryIO, long, is_str, iteritems
-    from .reader import HEADER_SCHEMA, SYNC_SIZE, MAGIC
-    from .schema import extract_named_schemas_into_repo, extract_record_type
+    from fastavro.six import utob, MemoryIO, long, is_str, iteritems
+    from fastavro.reader import HEADER_SCHEMA, SYNC_SIZE, MAGIC
+    from fastavro.schema import extract_named_schemas_into_repo,\
+        extract_record_type
 
 try:
     import simplejson as json
@@ -270,7 +272,7 @@ _base_types = [
     'string',
 ]
 
-SCHEMA_DEFS = {typ: typ for typ in _base_types}
+SCHEMA_DEFS = dict([(typ, typ) for typ in _base_types])
 
 
 def write_data(fo, datum, schema):
@@ -280,7 +282,8 @@ def write_data(fo, datum, schema):
 def write_header(fo, metadata, sync_marker):
     header = {
         'magic': MAGIC,
-        'meta': {key: utob(value) for key, value in iteritems(metadata)},
+        'meta': dict([(key, utob(value)) for key, value in
+                      iteritems(metadata)]),
         'sync': sync_marker
     }
     write_data(fo, header, HEADER_SCHEMA)

--- a/tests/test_str_py3.py
+++ b/tests/test_str_py3.py
@@ -17,7 +17,7 @@ def gen_id():
 
 keys = ['first', 'second', 'third', 'fourth']
 
-testdata = [{key: gen_id() for key in keys} for _ in range(50)]
+testdata = [dict([(key, gen_id()) for key in keys]) for _ in range(50)]
 
 schema = {
     "fields": [{'name': key, 'type': 'string'} for key in keys],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,pypy,pypy3,packaging
+envlist = py26,py27,py34,py35,pypy,pypy3,packaging
 
 [testenv]
 deps =


### PR DESCRIPTION
python 2.6 is still heavily used thanks to redhat/centos distributions so supporting it is useful.

this PR makes two minor changes to add the support:
* replacing dict comprehensions
* replacing relative imports