### PR TITLE
A potential fix for issue #49.

### DIFF
--- a/fastavro/writer.py
+++ b/fastavro/writer.py
@@ -202,8 +202,8 @@ def validate(datum, schema):
         return (
             isinstance(datum, Mapping) and
             all(
-                validate(datum.get(f['name'], f.get('default')), f['type']) 
-                if not (f['name'] not in datum and 
+                validate(datum.get(f['name'], f.get('default')), f['type'])
+                if not (f['name'] not in datum and
                         'default' not in f) else False
                 for f in schema['fields']
             )

--- a/fastavro/writer.py
+++ b/fastavro/writer.py
@@ -142,6 +142,8 @@ INT_MAX_VALUE = (1 << 31) - 1
 LONG_MIN_VALUE = -(1 << 63)
 LONG_MAX_VALUE = (1 << 63) - 1
 
+def no_value_and_no_default(datum, field):
+    return field['name'] not in datum and 'default' not in field
 
 def validate(datum, schema):
     """Determine if a python datum is an instance of a schema."""
@@ -202,9 +204,7 @@ def validate(datum, schema):
         return (
             isinstance(datum, Mapping) and
             all(
-                validate(datum.get(f['name'], f.get('default')), f['type'])
-                if not (f['name'] not in datum and
-                        'default' not in f) else False
+                (not no_value_and_no_default(datum, f)) and validate(datum.get(f['name'], f.get('default')), f['type'])
                 for f in schema['fields']
             )
         )

--- a/fastavro/writer.py
+++ b/fastavro/writer.py
@@ -202,7 +202,7 @@ def validate(datum, schema):
         return (
             isinstance(datum, Mapping) and
             all(
-                validate(datum.get(f['name']), f['type'])
+                validate(datum.get(f['name'], f.get('default')), f['type']) if not (f['name'] not in datum and 'default' not in f) else False
                 for f in schema['fields']
             )
         )
@@ -236,6 +236,11 @@ def write_record(fo, datum, schema):
     that they are declared. In other words, a record is encoded as just the
     concatenation of the encodings of its fields.  Field values are encoded per
     their schema."""
+    
+    if not validate(datum, schema):
+        msg = '%r (type %s) do not match %s' % (datum, type(datum), schema)
+        raise ValueError(msg)
+    
     for field in schema['fields']:
         write_data(fo,
                    datum.get(field['name'], field.get('default')),

--- a/fastavro/writer.py
+++ b/fastavro/writer.py
@@ -202,7 +202,9 @@ def validate(datum, schema):
         return (
             isinstance(datum, Mapping) and
             all(
-                validate(datum.get(f['name'], f.get('default')), f['type']) if not (f['name'] not in datum and 'default' not in f) else False
+                validate(datum.get(f['name'], f.get('default')), f['type']) 
+                if not (f['name'] not in datum and 
+                        'default' not in f) else False
                 for f in schema['fields']
             )
         )
@@ -236,11 +238,11 @@ def write_record(fo, datum, schema):
     that they are declared. In other words, a record is encoded as just the
     concatenation of the encodings of its fields.  Field values are encoded per
     their schema."""
-    
+
     if not validate(datum, schema):
         msg = '%r (type %s) do not match %s' % (datum, type(datum), schema)
         raise ValueError(msg)
-    
+
     for field in schema['fields']:
         write_data(fo,
                    datum.get(field['name'], field.get('default')),

--- a/fastavro/writer.py
+++ b/fastavro/writer.py
@@ -207,7 +207,7 @@ def validate(datum, schema):
             isinstance(datum, Mapping) and
             all(
                 (not no_value_and_no_default(datum, f)) and
-                  validate(datum.get(f['name'], f.get('default')), f['type'])
+                validate(datum.get(f['name'], f.get('default')), f['type'])
                 for f in schema['fields']
             )
         )

--- a/fastavro/writer.py
+++ b/fastavro/writer.py
@@ -142,8 +142,10 @@ INT_MAX_VALUE = (1 << 31) - 1
 LONG_MIN_VALUE = -(1 << 63)
 LONG_MAX_VALUE = (1 << 63) - 1
 
+
 def no_value_and_no_default(datum, field):
     return field['name'] not in datum and 'default' not in field
+
 
 def validate(datum, schema):
     """Determine if a python datum is an instance of a schema."""
@@ -204,7 +206,8 @@ def validate(datum, schema):
         return (
             isinstance(datum, Mapping) and
             all(
-                (not no_value_and_no_default(datum, f)) and validate(datum.get(f['name'], f.get('default')), f['type'])
+                (not no_value_and_no_default(datum, f)) and
+                  validate(datum.get(f['name'], f.get('default')), f['type'])
                 for f in schema['fields']
             )
         )

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -234,7 +234,24 @@ def test_default_values():
     new_records = list(new_reader)
     assert new_records == [{"default_field": "default_value"}]
 
-
+def test_missing_value_for_null_union_without_default():
+    #https://github.com/tebeka/fastavro/issues/37
+    schema = {
+        "type" : "record",
+        "fields" : [ {
+            "name" : "x",
+            "type" : [ "int", "null" ]
+        } ]
+    }
+    new_file = MemoryIO()
+    records = [{}]
+    
+    try:
+        fastavro.writer(new_file, schema, records)
+        assert False, 'Never raised'
+    except ValueError:
+        pass
+    
 def test_boolean_roundtrip():
     schema = {
         "type": "record",

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -234,24 +234,26 @@ def test_default_values():
     new_records = list(new_reader)
     assert new_records == [{"default_field": "default_value"}]
 
+
 def test_missing_value_for_null_union_without_default():
-    #https://github.com/tebeka/fastavro/issues/37
+    # https://github.com/tebeka/fastavro/issues/37
     schema = {
-        "type" : "record",
-        "fields" : [ {
-            "name" : "x",
-            "type" : [ "int", "null" ]
-        } ]
+        "type": "record",
+        "fields": [{
+            "name": "x",
+            "type": ["int", "null"]
+        }]
     }
     new_file = MemoryIO()
     records = [{}]
-    
+
     try:
         fastavro.writer(new_file, schema, records)
         assert False, 'Never raised'
     except ValueError:
         pass
-    
+
+
 def test_boolean_roundtrip():
     schema = {
         "type": "record",


### PR DESCRIPTION
Have the record validate itself before writing out.

We don't technically need to do this level of validation. It was done this way to avoid duplicating code between validate([#L205](https://github.com/tebeka/fastavro/blob/53648c81598f40765ef6bd48923a92255ebcc429/fastavro/writer.py#L205)) and write_record ([#L241](https://github.com/tebeka/fastavro/blob/53648c81598f40765ef6bd48923a92255ebcc429/fastavro/writer.py#L241)), as both need to do the check. 

I think the only case where this is a problem is the case where the field is a union with null. So there is probably a way to rework this to have less overhead. But I'll leave this to your direction @tebeka. 
