### PR TITLE
better stacktrace info on write errors

### DIFF
--- a/fastavro/exceptions.py
+++ b/fastavro/exceptions.py
@@ -1,0 +1,10 @@
+class AvroValueError(ValueError):
+    @classmethod
+    def from_traceback(cls, datum, schema, path, traceback):
+        msg = '\n'.join([
+            'Exception traceback: %s' % traceback,
+            'Path is: %s' % '.'.join(path),
+            'Datum is %s of type %s' % (datum, type(datum)),
+            'Expected avro schema type: %s' % schema,
+        ])
+        return cls(msg)

--- a/tests/test_avro_value_error.py
+++ b/tests/test_avro_value_error.py
@@ -1,0 +1,99 @@
+import fastavro
+from fastavro.exceptions import AvroValueError
+
+from fastavro.six import MemoryIO
+
+
+def assert_error(schema, records, message_substring):
+    fo = MemoryIO()
+    try:
+        fastavro.writer(fo, schema, records)
+    except AvroValueError as e:
+        assert message_substring in str(e)
+    else:
+        assert False, 'AvroValueError should have been raised'
+
+
+def test_correct_record_indexing():
+    schema = {
+        "type": "record",
+        "name": "test_record",
+        "fields": [{
+            "name": "test",
+            "type": "string",
+        }]
+    }
+
+    records = [{'test': None}]
+    assert_error(schema, records, '<record[0]>')
+
+    records = [{'test': 'a'}, {'test': None}]
+    assert_error(schema, records, '<record[1]>')
+
+
+def test_correct_field_detection():
+    schema = {
+        "type": "record",
+        "name": "test_record",
+        "fields": [{
+            "name": "A",
+            "type": "string",
+        }, {
+            "name": "B",
+            "type": "string",
+        }, {
+            "name": "C",
+            "type": "string",
+        }]
+    }
+
+    records = [{'A': None, 'B': 'foo', 'C': 'foo'}]
+    assert_error(schema, records, '<field[A]>')
+
+    records = [{'A': 'foo', 'B': None, 'C': 'foo'}]
+    assert_error(schema, records, '<field[B]>')
+
+
+def test_correct_array_indexing():
+    schema = {
+        "type": "record",
+        "name": "test_record",
+        "fields": [{
+            "name": "foo",
+            "type": {
+                "type": "array",
+                "items": "int",
+            },
+        }]
+    }
+
+    records = [{'foo': [None, 1, 2]}]
+    assert_error(schema, records, '<array[0]>')
+
+    records = [{'foo': [0, None, 2]}]
+    assert_error(schema, records, '<array[1]>')
+
+
+def test_correct_map_indexing():
+    schema = {
+        "type": "record",
+        "name": "test_record",
+        "fields": [{
+            "name": "foo",
+            "type": {
+                "type": "map",
+                "values": "int",
+            },
+        }]
+    }
+
+    # Invalid map key
+    records = [{'foo': {'key': 0, None: 1}}]
+    assert_error(schema, records, '<map_key[None]>')
+
+    # Invalide map values
+    records = [{'foo': {'key': None, 'key2': 1}}]
+    assert_error(schema, records, '<map_value[key]>')
+
+    records = [{'foo': {'key': 0, 'key2': None}}]
+    assert_error(schema, records, '<map_value[key2]>')


### PR DESCRIPTION
This is a subset of https://github.com/tebeka/fastavro/pull/41 that only includes the error path tracking for write operations. I unrolled some of the decorators from that PR (which while much more elegant, probably added more overhead).

An example stacktrace looks like this:
```python
Traceback (most recent call last):
  File "/Users/scott/.virtualenvs/fastavro/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/scott/git/scottbelden/fastavro/tests/test_fastavro.py", line 329, in test_repo_caching_issue
    fastavro.writer(new_file, other_schema, records)
  File "/Users/scott/git/scottbelden/fastavro/fastavro/writer.py", line 457, in writer
    write_data(io, record, schema, path)
  File "/Users/scott/git/scottbelden/fastavro/fastavro/writer.py", line 310, in write_data
    path=path)
  File "/Users/scott/git/scottbelden/fastavro/fastavro/writer.py", line 254, in write_record
    path=path)
  File "/Users/scott/git/scottbelden/fastavro/fastavro/writer.py", line 310, in write_data
    path=path)
  File "/Users/scott/git/scottbelden/fastavro/fastavro/writer.py", line 375, in <lambda>
    path),
  File "/Users/scott/git/scottbelden/fastavro/fastavro/writer.py", line 310, in write_data
    path=path)
  File "/Users/scott/git/scottbelden/fastavro/fastavro/writer.py", line 254, in write_record
    path=path)
  File "/Users/scott/git/scottbelden/fastavro/fastavro/writer.py", line 310, in write_data
    path=path)
  File "/Users/scott/git/scottbelden/fastavro/fastavro/writer.py", line 254, in write_record
    path=path)
  File "/Users/scott/git/scottbelden/fastavro/fastavro/writer.py", line 315, in write_data
    raise AvroValueError.from_traceback(datum, schema, path, tb)
AvroValueError: Exception traceback: Traceback (most recent call last):
  File "/Users/scott/git/scottbelden/fastavro/fastavro/writer.py", line 310, in write_data
    path=path)
  File "/Users/scott/git/scottbelden/fastavro/fastavro/writer.py", line 51, in write_int
    datum = (datum << 1) ^ (datum >> 63)
TypeError: unsupported operand type(s) for <<: 'str' and 'int'

Path is: <record[0]>.<field[aa]>.<field[b]>.<field[c]>
Datum is 2 of type <type 'str'>
Expected avro schema type: int
```

I did some profiling and the results are here: https://gist.github.com/scottbelden/418e2523dee10da0798978ec97226627

I would ignore the overall timing and rather just note that every function call has the exact same number of calls except of course ```{method 'append' of 'list' objects}``` which is only present in the run which included the changes in this PR. While there are 336,365 calls, it doesn't add that much overhead (i.e. 32 thousandths of a second).

Please let me know what you think.