### PR TITLE
better error information when serialization fails

### DIFF
--- a/fastavro/constants.py
+++ b/fastavro/constants.py
@@ -1,0 +1,4 @@
+INT_MIN_VALUE = -(1 << 31)
+INT_MAX_VALUE = (1 << 31) - 1
+LONG_MIN_VALUE = -(1 << 63)
+LONG_MAX_VALUE = (1 << 63) - 1

--- a/fastavro/validate.py
+++ b/fastavro/validate.py
@@ -1,0 +1,152 @@
+try:
+    from fastavro._constants import INT_MIN_VALUE, INT_MAX_VALUE,\
+        LONG_MIN_VALUE, LONG_MAX_VALUE
+    from fastavro._six import long, is_str, iteritems
+    from fastavro._schema import extract_record_type
+except ImportError:
+    from fastavro.constants import INT_MIN_VALUE, INT_MAX_VALUE,\
+        LONG_MIN_VALUE, LONG_MAX_VALUE
+    from fastavro.six import long, is_str, iteritems
+    from fastavro.schema import extract_record_type
+
+from collections import Iterable, Mapping
+
+
+def _extract_record_type(schema):
+    """Returns the schema type. If it is a record or enum, the namespaced name
+    will be returned"""
+    _type = extract_record_type(schema)
+    if _type in ('record', 'error', 'request', 'enum',):
+        namespace = schema.get('namespace')
+        name = schema.get('name', _type)
+        if namespace:
+            _type = '.'.join([namespace, name])
+        else:
+            _type = name
+    return _type
+
+
+def validate_data(datum, schema, schema_defs):
+    """A validator that walks the schema and is able to determine exactly where
+    in the schema a problem might exist"""
+    err_msg = _validate(datum, schema, schema_defs)
+    if err_msg:
+        raise ValueError(err_msg)
+    else:
+        return True
+
+
+def _validate(datum, schema, schema_defs):
+    """Determine if a python datum is an instance of a schema."""
+
+    record_type = extract_record_type(schema)
+
+    if record_type == 'null':
+        if datum is not None:
+            return u'%s is not None' % type(datum)
+        return None
+
+    if record_type == 'boolean':
+        if not isinstance(datum, bool):
+            return u'%s is not a boolean' % type(datum)
+        return None
+
+    if record_type == 'string':
+        if not is_str(datum):
+            return u'%s is not a string' % type(datum)
+        return None
+
+    if record_type == 'bytes':
+        if not isinstance(datum, bytes):
+            return u'%s is not bytes' % type(datum)
+        return None
+
+    if record_type == 'int':
+        if not (isinstance(datum, (int, long,)) and
+                INT_MIN_VALUE <= datum <= INT_MAX_VALUE):
+            return u'%s is not an int' % type(datum)
+        return None
+
+    if record_type == 'long':
+        if not (isinstance(datum, (int, long,)) and
+                LONG_MIN_VALUE <= datum <= LONG_MAX_VALUE):
+            return u'%s is not a long' % type(datum)
+        return None
+
+    if record_type in ['float', 'double']:
+        if not isinstance(datum, (int, long, float)):
+            return u'%s is not a float or a double' % type(datum)
+        return None
+
+    if record_type == 'fixed':
+        if not (isinstance(datum, bytes) and len(datum) == schema['size']):
+            return u'%s is not fixed' % type(datum)
+        return None
+
+    if record_type == 'union':
+        err_msgs = []
+        for s in schema:
+            err_msg = _validate(datum, s, schema_defs)
+            if err_msg:
+                err_msgs.append(err_msg)
+            else:
+                return None
+
+        # If we haven't returned by now, none of the schemas were okay
+        s_types = ','.join([_extract_record_type(s) for s in schema])
+        union_err = u'%s is not one of %r' % (type(datum), s_types)
+        return union_err + '; Potential Reasons:\n   ' + '\n   '.join(err_msgs)
+
+    # dict-y types from here on.
+    if record_type == 'enum':
+        if datum not in schema['symbols']:
+            msg = u'<%s[%s]>: %s not in symbols %s'
+            return msg % (_extract_record_type(schema),
+                          datum,
+                          datum,
+                          schema['symbols'])
+
+        return None
+
+    if record_type == 'array':
+        if not isinstance(datum, Iterable):
+            return u'%s is not iterable' % type(datum)
+
+        for idx, d in enumerate(datum):
+            err_msg = _validate(d, schema['items'], schema_defs)
+            if err_msg:
+                return u'<array[%d]>: %s' % (idx, err_msg)
+
+        return None
+
+    if record_type == 'map':
+        if not isinstance(datum, Mapping):
+            return u'%s is not a map' % type(datum)
+
+        for k, v in iteritems(datum):
+            if not is_str(k):
+                return u'<map[%r]>: Invalid key' % k
+
+            err_msg = _validate(v, schema['values'], schema_defs)
+            if err_msg:
+                return u'<map[%s]>: %s' % (k, err_msg)
+
+        return None
+
+    if record_type in ('record', 'error', 'request',):
+        if not isinstance(datum, Mapping):
+            return u'%s is not a record dictionary' % type(datum)
+
+        for f in schema['fields']:
+            err_msg = _validate(datum.get(f['name']), f['type'], schema_defs)
+            if err_msg:
+                return u'<%s><field[%s]>: %s' % (_extract_record_type(schema),
+                                                 f['name'],
+                                                 err_msg)
+
+        return None
+
+    if record_type in schema_defs:
+        return _validate(datum, schema_defs[record_type], schema_defs)
+
+    raise ValueError('unkown record type - %s' % record_type)

--- a/fastavro/writer.py
+++ b/fastavro/writer.py
@@ -7,15 +7,21 @@
 # Apache 2.0 license (http://www.apache.org/licenses/LICENSE-2.0)
 
 try:
+    from fastavro._constants import INT_MIN_VALUE, INT_MAX_VALUE,\
+        LONG_MIN_VALUE, LONG_MAX_VALUE
     from fastavro._six import utob, MemoryIO, long, is_str, iteritems
     from fastavro._reader import HEADER_SCHEMA, SYNC_SIZE, MAGIC
     from fastavro._schema import extract_named_schemas_into_repo,\
         extract_record_type
+    from fastavro._validate import validate_data
 except ImportError:
+    from fastavro.constants import INT_MIN_VALUE, INT_MAX_VALUE,\
+        LONG_MIN_VALUE, LONG_MAX_VALUE
     from fastavro.six import utob, MemoryIO, long, is_str, iteritems
     from fastavro.reader import HEADER_SCHEMA, SYNC_SIZE, MAGIC
     from fastavro.schema import extract_named_schemas_into_repo,\
         extract_record_type
+    from fastavro.validate import validate_data
 
 try:
     import simplejson as json
@@ -135,12 +141,6 @@ def write_map(fo, datum, schema):
             write_utf8(fo, key)
             write_data(fo, val, vtype)
     write_long(fo, 0)
-
-
-INT_MIN_VALUE = -(1 << 31)
-INT_MAX_VALUE = (1 << 31) - 1
-LONG_MIN_VALUE = -(1 << 63)
-LONG_MAX_VALUE = (1 << 63) - 1
 
 
 def validate(datum, schema):
@@ -425,7 +425,11 @@ def writer(fo,
     acquaint_schema(schema)
 
     for record in records:
-        write_data(io, record, schema)
+        try:
+            write_data(io, record, schema)
+        except Exception as e:
+            validate_data(record, schema, SCHEMA_DEFS)
+            raise e
         block_count += 1
         if io.tell() >= sync_interval:
             dump()
@@ -451,4 +455,8 @@ def schemaless_writer(fo, schema, record):
 
     """
     acquaint_schema(schema)
-    write_data(fo, record, schema)
+    try:
+        write_data(fo, record, schema)
+    except Exception as e:
+        validate_data(record, schema, SCHEMA_DEFS)
+        raise e

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,131 @@
+import fastavro
+
+from fastavro.six import MemoryIO
+
+
+def assert_error(schema, records, message_substring):
+    fo = MemoryIO()
+    try:
+        fastavro.writer(fo, schema, records)
+    except ValueError as e:
+        assert message_substring in str(e)
+    else:
+        assert False, 'ValueError should have been raised'
+
+
+def test_correct_record_naming():
+    name = 'test_record'
+    namespace = 'test_namespace'
+
+    schema = {
+        "type": "record",
+        "fields": [{
+            "name": "test",
+            "type": "string",
+        }]
+    }
+
+    # No name
+    records = [{'test': None}]
+    assert_error(schema, records, '<record>')
+
+    # Name only
+    schema['name'] = name
+    records = [{'test': None}]
+    assert_error(schema, records, '<%s>' % name)
+
+    # Name and namespace
+    schema['namespace'] = namespace
+    records = [{'test': 'a'}, {'test': None}]
+    assert_error(schema, records, '<%s.%s>' % (namespace, name))
+
+
+def test_correct_field_detection():
+    schema = {
+        "type": "record",
+        "name": "test_record",
+        "fields": [{
+            "name": "A",
+            "type": "string",
+        }, {
+            "name": "B",
+            "type": "string",
+        }, {
+            "name": "C",
+            "type": "string",
+        }]
+    }
+
+    records = [{'A': None, 'B': 'foo', 'C': 'foo'}]
+    assert_error(schema, records, '<field[A]>')
+
+    records = [{'A': 'foo', 'B': None, 'C': 'foo'}]
+    assert_error(schema, records, '<field[B]>')
+
+
+def test_correct_array_indexing():
+    schema = {
+        "type": "record",
+        "name": "test_record",
+        "fields": [{
+            "name": "foo",
+            "type": {
+                "type": "array",
+                "items": "int",
+            },
+        }]
+    }
+
+    records = [{'foo': [None, 1, 2]}]
+    assert_error(schema, records, '<array[0]>')
+
+    records = [{'foo': [0, None, 2]}]
+    assert_error(schema, records, '<array[1]>')
+
+
+def test_correct_map_indexing():
+    schema = {
+        "type": "record",
+        "name": "test_record",
+        "fields": [{
+            "name": "foo",
+            "type": {
+                "type": "map",
+                "values": "int",
+            },
+        }]
+    }
+
+    # Invalid map key
+    records = [{'foo': {'key': 0, None: 1}}]
+    assert_error(schema, records, '<map[None]>')
+
+    # Invalide map values
+    records = [{'foo': {'key': None, 'key2': 1}}]
+    assert_error(schema, records, '<map[key]>')
+
+    records = [{'foo': {'key': 0, 'key2': None}}]
+    assert_error(schema, records, '<map[key2]>')
+
+
+def test_enums():
+    name = 'test_enum'
+    namespace = 'test_namespace'
+    schema = {
+        "type": "enum",
+        "symbols": ["FOO", "BAR"],
+    }
+
+    # No name
+    records = ['INVALID']
+    assert_error(schema, records, '<enum[INVALID]>')
+
+    # Name only
+    schema['name'] = name
+    records = ['INVALID']
+    assert_error(schema, records, '<%s[INVALID]>' % name)
+
+    # Name and namespace
+    schema['namespace'] = namespace
+    records = ['INVALID']
+    assert_error(schema, records, '<%s.%s[INVALID]>' % (namespace, name))


### PR DESCRIPTION
Alternative approach to https://github.com/tebeka/fastavro/pull/52 that doesn't add extra overhead to the serialization and instead re-walks the schema and datum to determine the problem when serialization fails.

There are still a few pieces that could be polished a little like the printing of union errors, but just putting this up here to let travis test it and get feedback on this approach vs https://github.com/tebeka/fastavro/pull/52.