### PR TITLE
Fix ImmutableDict is not hashable error when running with python3

### DIFF
--- a/fastavro/schema.py
+++ b/fastavro/schema.py
@@ -1,5 +1,6 @@
 # cython: auto_cpdef=True
 
+from avro.schema import ImmutableDict
 
 PRIMITIVES = set([
     'boolean',
@@ -42,6 +43,9 @@ def schema_name(schema, parent_ns):
 
 
 def extract_named_schemas_into_repo(schema, repo, transformer, parent_ns=None):
+    if isinstance(schema, ImmutableDict):
+        schema = dict(schema)
+
     if type(schema) == list:
         for index, enum_schema in enumerate(schema):
             namespaced_name = extract_named_schemas_into_repo(


### PR DESCRIPTION
Hello,

I had the following issue when running fastavro module with Python 3.5.1:

> Traceback (most recent call last):
>   File "geoimage_to_hdfs_tiles_avro.py", line 160, in write_avro_file
>     with AvroWriter(client, output_filename, schema=schema.to_json()) as writer:
>   File "/usr/lib/python3/dist-packages/hdfs/ext/avro/**init**.py", line 265, in **enter**
>     self._writer.send(None) # Prime coroutine.
>   File "/usr/lib/python3/dist-packages/hdfs/ext/avro/__init__.py", line 329, in _write
>     dump_header()
>   File "/usr/lib/python3/dist-packages/hdfs/ext/avro/__init__.py", line 318, in dump_header
>     fastavro._writer.acquaint_schema(self._schema)
>   File "/usr/lib/python3/dist-packages/fastavro/writer.py", line 348, in acquaint_schema
>     lambda schema: lambda fo, datum, _: write_data(fo, datum, schema),
>   File "/usr/lib/python3/dist-packages/fastavro/schema.py", line 100, in extract_named_schemas_into_repo
>     namespace,
>   File "/usr/lib/python3/dist-packages/fastavro/schema.py", line 61, in extract_named_schemas_into_repo
>     if schema not in PRIMITIVES and '.' not in schema and parent_ns:
> TypeError: unhashable type: 'ImmutableDict'

I'm not sure of why an ImmutableDict would be unhashable but I'm pretty sure we don't mind here if we cast it back to regular dict. At least, the code is running for me now.

PS: When running the code with Python 2.7 schema object here is a dict not and ImmutableDict and there's no error.

Best regards, Adam.
