### PR TITLE
Load schema recursively

### DIFF
--- a/fastavro/schema.py
+++ b/fastavro/schema.py
@@ -121,6 +121,9 @@ def _load_schema(schema, schema_dir):
     try:
         acquaint_schema(schema)  # NOQA
     except UnknownType as e:
-        load_schema(os.path.join(schema_dir, '{}.avsc'.format(e.name)))
+        try:
+            load_schema(os.path.join(schema_dir, '{}.avsc'.format(e.name)))
+        except IOError:
+            raise e
         _load_schema(schema, schema_dir)
     return schema

--- a/tests/avro-files/Child.avsc
+++ b/tests/avro-files/Child.avsc
@@ -1,0 +1,5 @@
+{
+  "type":"record",
+  "name":"Child",
+  "fields":[]
+}

--- a/tests/avro-files/Parent.avsc
+++ b/tests/avro-files/Parent.avsc
@@ -1,0 +1,10 @@
+{
+  "type":"record",
+  "name":"Parent",
+  "fields":[
+    {
+      "name": "child",
+      "type": "Child"
+    }
+  ]
+}

--- a/tests/avro-files/ParentMissingChild.avsc
+++ b/tests/avro-files/ParentMissingChild.avsc
@@ -1,0 +1,10 @@
+{
+  "type":"record",
+  "name":"ParentMissingChild",
+  "fields":[
+    {
+      "name": "child",
+      "type": "Missing"
+    }
+  ]
+}

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -199,6 +199,12 @@ def test_acquaint_schema_accepts_nested_records_from_arrays():
     assert 'Nested' in fastavro._writer.SCHEMA_DEFS
 
 
+def test_compose_schemas():
+    schema_path = join(data_dir, 'Parent.avsc')
+    fastavro._schema.load_schema(schema_path)
+    assert 'Child' in fastavro._writer.SCHEMA_DEFS
+
+
 def test_schemaless_writer_and_reader():
     schema = {
         "type": "record",

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -201,8 +201,14 @@ def test_acquaint_schema_accepts_nested_records_from_arrays():
 
 def test_compose_schemas():
     schema_path = join(data_dir, 'Parent.avsc')
-    fastavro._schema.load_schema(schema_path)
+    fastavro.schema.load_schema(schema_path)
     assert 'Child' in fastavro._writer.SCHEMA_DEFS
+
+
+@raises(fastavro.schema.UnknownType)
+def test_missing_schema():
+    schema_path = join(data_dir, 'ParentMissingChild.avsc')
+    fastavro.schema.load_schema(schema_path)
 
 
 def test_schemaless_writer_and_reader():


### PR DESCRIPTION
resolves #55 

The way it checks to see if a schema is already registered is probably an abuse of the UnkownType exception. Probably not a big deal but let me know if you would like to do that check another way.