### PR TITLE
Fix block count corruption on writer.flush() after an auto-sync

### DIFF
--- a/fastavro/writer.py
+++ b/fastavro/writer.py
@@ -387,6 +387,7 @@ class Writer(object):
         self.fo.write(self.sync_marker)
         self.io.truncate(0)
         self.io.seek(0, SEEK_SET)
+        self.block_count = 0
 
     def write(self, record):
         if self.validate_fn:
@@ -395,7 +396,6 @@ class Writer(object):
         self.block_count += 1
         if self.io.tell() >= self.sync_interval:
             self.dump()
-            self.block_count = 0
 
     def flush(self):
         if self.io.tell() or self.block_count > 0:


### PR DESCRIPTION
Small change - I think it seems right to reset the block count to zero whenever you do `writer.dump()` (whether through an auto-sync or a manual `flush()`). Otherwise `dump()` can be called with no available blocks, which seems to be bad.