### PR TITLE
Added an optional shortcut when outputting a union

### DIFF
--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -309,6 +309,42 @@ def test_metadata():
     assert new_reader.metadata['key'] == metadata['key']
 
 
+def test_write_union_shortcut():
+    schema = {
+        "type": "record",
+        "name": "A",
+        "fields": [{
+            "name": "a",
+            "type": [
+                {
+                    "type": "record",
+                    "name": "B",
+                    "fields": [{
+                        "name": "b",
+                        "type": "string"
+                    }]
+                },
+                {
+                    "type": "record",
+                    "name": "C",
+                    "fields": [{
+                        "name": "c",
+                        "type": "string"
+                    }]
+                }
+            ]
+        }]
+    }
+
+    new_file = MemoryIO()
+    records = [{"a": ("B", {"b": "test"})}]
+    fastavro.writer(new_file, schema, records)
+    new_file.seek(0)
+    new_reader = fastavro.reader(new_file)
+    new_records = list(new_reader)
+    assert new_records == [{"a": {"b": "test"}}]
+
+
 def test_repo_caching_issue():
     schema = {
         "type": "record",


### PR DESCRIPTION
Added an optional shortcut when outputting a union that allows the user to provide a tuple containing the name of the record.  

This is used to lookup the appropriate schema by name instead of performing validation on all options.

It is completely backwards compatible with existing Avro serialization, but allows faster union write if the user provides a tuple in the format of (name, record) instead of simply the record itself.

A first attempt at a solution for #68 
Sorry for the delay in the pull request.

Timing comparison:

Schema:
<details><summary>Click to expand</summary><p>

```
protocol test {
    record a {
        int a;
        int b;
        int c0;
    }
    record b {
        int a;
        int b;
        int c1;
    }
    record c {
        int a;
        int b;
        int c2;
    }
    record d {
        int a;
        int b;
        int c3;
    }
    record e {
        int a;
        int b;
        int c4;
    }
    record f {
        int a;
        int b;
        int c5;
    }
    record g {
        int a;
        int b;
        int c6;
    }
    record h {
        int a;
        int b;
        int c7;
    }
    record i {
        int a;
        int b;
        int c8;
    }
    record j {
        int a;
        int b;
        int c9;
    }
    record k {
        int a;
        int b;
        int c10;
    }
    record l {
        int a;
        int b;
        int c11;
    }
    record m {
        int a;
        int b;
        int c12;
    }
    record n {
        int a;
        int b;
        int c13;
    }
    record o {
        int a;
        int b;
        int c14;
    }
    record p {
        int a;
        int b;
        int c15;
    }
    record q {
        int a;
        int b;
        int c16;
    }
    record r {
        int a;
        int b;
        int c17;
    }
    record s {
        int a;
        int b;
        int c18;
    }
    record t {
        int a;
        int b;
        int c19;
    }
    record u {
        int a;
        int b;
        int c20;
    }
    record v {
        int a;
        int b;
        int c21;
    }
    record w {
        int a;
        int b;
        int c22;
    }
    record x {
        int a;
        int b;
        int c23;
    }
    record y {
        int a;
        int b;
        int c24;
    }
    record z {
        int a;
        int b;
        int c25;
    }
    record root {
        union { a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z } field;
    }
}
```

</p></details>

Test script:
```python
import timeit

setup = """
import fastavro
import json

from cStringIO import StringIO

with open('root.avsc') as f:
    schema = json.loads(f.read())
"""

stmt = """
output = StringIO()
fastavro.writer(output, schema, messages)
"""

setup_without_tuple = setup + 'messages = [{"field": {"a": 1, "b": 2, "c20": 3}}] * 100'
setup_with_tuple = setup + 'messages = [{"field": ("u", {"a": 1, "b": 2, "c20": 3})}] * 100'
    
result = timeit.timeit(stmt, setup=setup_without_tuple, number=1000)
print "Without Tuple: {0}".format(result)

result = timeit.timeit(stmt, setup=setup_with_tuple, number=1000)
print "With Tuple: {0}".format(result)
```

Output:
```
# python speed_test.py
Without Tuple: 30.857667923
With Tuple: 3.69382190704
```