### PR TITLE
date-time logical types support

### DIFF
--- a/fastavro/writer.py
+++ b/fastavro/writer.py
@@ -22,6 +22,7 @@ except ImportError:
     from fastavro.schema import extract_named_schemas_into_repo,\
         extract_record_type
 
+import datetime
 try:
     import simplejson as json
 except ImportError:
@@ -184,15 +185,16 @@ def validate(datum, schema):
         return isinstance(datum, bytes)
 
     if record_type == 'int':
-        return (
-            isinstance(datum, (int, long,)) and
-            INT_MIN_VALUE <= datum <= INT_MAX_VALUE
-        )
+        return (isinstance(datum, datetime.date) or
+                (isinstance(datum, (int, long,)) and
+                INT_MIN_VALUE <= datum <= INT_MAX_VALUE)
+                )
 
     if record_type == 'long':
         return (
-            isinstance(datum, (int, long,)) and
-            LONG_MIN_VALUE <= datum <= LONG_MAX_VALUE
+            isinstance(datum, datetime.datetime) or
+            (isinstance(datum, (int, long,)) and
+             LONG_MIN_VALUE <= datum <= LONG_MAX_VALUE)
         )
 
     if record_type in ['float', 'double']:

--- a/fastavro/writer.py
+++ b/fastavro/writer.py
@@ -7,6 +7,11 @@
 # Apache 2.0 license (http://www.apache.org/licenses/LICENSE-2.0)
 
 try:
+    from UserDict import UserDict
+except ImportError:
+    from collections import UserDict
+
+try:
     from fastavro._six import utob, MemoryIO, long, is_str, iteritems
     from fastavro._reader import HEADER_SCHEMA, SYNC_SIZE, MAGIC
     from fastavro._schema import extract_named_schemas_into_repo,\
@@ -22,6 +27,7 @@ try:
 except ImportError:
     import json
 
+import time
 from binascii import crc32
 from collections import Iterable, Mapping
 from os import urandom, SEEK_SET
@@ -40,6 +46,23 @@ def write_boolean(fo, datum, schema=None):
     """A boolean is written as a single byte whose value is either 0 (false) or
     1 (true)."""
     fo.write(pack('B', 1 if datum else 0))
+
+
+def write_timestamp_millis(fo, datum, schema=None):
+    t = int(time.mktime(datum.timetuple())) * 1000 + int(
+        datum.microsecond / 1000)
+    write_int(fo, t, schema)
+    # write_int(fo, int(datum.timestamp() * 1000), schema)
+
+
+def write_timestamp_micros(fo, datum, schema=None):
+    t = int(time.mktime(datum.timetuple())) * 1000000 + datum.microsecond
+    write_int(fo, t, schema)
+    # write_int(fo, int(datum.timestamp() * 1000000), schema)
+
+
+def write_date(fo, datum, schema=None):
+    write_int(fo, datum.toordinal(), schema)
 
 
 def write_int(fo, datum, schema=None):
@@ -264,7 +287,33 @@ def write_record(fo, datum, schema):
             name, field.get('default')), field['type'])
 
 
-WRITERS = {
+LOGICALWRITERS = {
+    'long-timestamp-millis': write_timestamp_millis,
+    'long-timestamp-micros': write_timestamp_micros,
+    'int-date': write_date
+}
+
+
+class Writers(UserDict):
+    def __getitem__(self, key):
+        rt = extract_record_type(key)
+        if rt == 'record':
+            return self.data[rt]
+        try:
+            return self.data.__getitem__(key)
+        except:
+            pass
+        if isinstance(key, dict):
+            if "logicalType" not in key:
+                return self.data[rt]
+            return LOGICALWRITERS[key['type'] + "-" + key['logicalType']]
+        if isinstance(key, list):
+            return self.data['union']
+
+
+WRITERS = Writers()
+
+WRITERS.update({
     'null': write_null,
     'boolean': write_boolean,
     'string': write_utf8,
@@ -281,7 +330,7 @@ WRITERS = {
     'error_union': write_union,
     'record': write_record,
     'error': write_record,
-}
+})
 
 _base_types = [
     'boolean',
@@ -309,7 +358,8 @@ def write_data(fo, datum, schema):
     schema: dict
         Schemda to use
     """
-    return WRITERS[extract_record_type(schema)](fo, datum, schema)
+    fn = WRITERS[schema]
+    return fn(fo, datum, schema)
 
 
 def write_header(fo, metadata, sync_marker):

--- a/tests/test_logical_types.py
+++ b/tests/test_logical_types.py
@@ -1,0 +1,57 @@
+import datetime
+from io import BytesIO
+
+import fastavro
+
+schema = {
+    "fields": [
+        {
+            "name": "date",
+            "type": {'type': 'int', 'logicalType': 'date'}
+        },
+        {
+            "name": "timestamp-millis",
+            "type": {'type': 'long', 'logicalType': 'timestamp-millis'}
+        },
+        {
+            "name": "timestamp-micros",
+            "type": {'type': 'long', 'logicalType': 'timestamp-micros'}
+        },
+    ],
+    "namespace": "namespace",
+    "name": "name",
+    "type": "record"
+}
+
+
+def serialize(schema, data):
+    bytes_writer = BytesIO()
+    fastavro.schemaless_writer(bytes_writer, schema, data)
+    return bytes_writer.getvalue()
+
+
+def deserialize(schema, binary):
+    bytes_writer = BytesIO()
+    bytes_writer.write(binary)
+    bytes_writer.seek(0)
+
+    res = fastavro.schemaless_reader(bytes_writer, schema)
+    return res
+
+
+def test_logical_types():
+    data1 = {
+        'date': datetime.date.today(),
+        'timestamp-millis': datetime.datetime.now(),
+        'timestamp-micros': datetime.datetime.now(),
+
+    }
+    binary = serialize(schema, data1)
+    data2 = deserialize(schema, binary)
+    assert (data1['date'] == data2['date'])
+    assert (data1['timestamp-micros'] == data2['timestamp-micros'])
+    assert (int(data1['timestamp-millis'].microsecond / 1000) == int(data2[
+        'timestamp-millis'].microsecond))
+
+
+test_logical_types()

--- a/tests/test_logical_types.py
+++ b/tests/test_logical_types.py
@@ -50,8 +50,30 @@ def test_logical_types():
     data2 = deserialize(schema, binary)
     assert (data1['date'] == data2['date'])
     assert (data1['timestamp-micros'] == data2['timestamp-micros'])
-    assert (int(data1['timestamp-millis'].microsecond / 1000) == int(data2[
-        'timestamp-millis'].microsecond))
+    assert (int(data1['timestamp-millis'].microsecond / 1000) ==
+            int(data2['timestamp-millis'].microsecond))
 
 
-test_logical_types()
+schema_null = {
+    "fields": [
+        {
+            "name": "date",
+            "type": ["null", {'type': 'int', 'logicalType': 'date'}]
+        },
+    ],
+    "namespace": "namespace",
+    "name": "name",
+    "type": "record"
+}
+
+
+def test_null():
+    data1 = {
+        # 'date': None,
+    }
+    binary = serialize(schema_null, data1)
+    data2 = deserialize(schema_null, binary)
+    assert (data2['date'] is None)
+
+
+test_null()


### PR DESCRIPTION
Processing avro`s logical types requires more complicaded dispatching.
To do this with minimal changes UserDict with custom getitem on READERS\WRITERS are used.