### PR TITLE
avro 1.8 logical types support

### DIFF
--- a/fastavro/reader.py
+++ b/fastavro/reader.py
@@ -9,23 +9,22 @@
 import json
 from struct import unpack, error as StructError
 from zlib import decompress
-from os import SEEK_SET
 import datetime
 from decimal import getcontext, Decimal
 
 import struct
 
 try:
-    from fastavro._six import MemoryIO, xrange, btou, utob, iteritems,\
+    from ._six import MemoryIO, xrange, btou, utob, iteritems,\
         is_str, PY3
-    from fastavro._schema import (
+    from ._schema import (
         extract_record_type, acquaint_schema, populate_schema_defs,
         extract_logical_type
     )
 except ImportError:
-    from fastavro.six import MemoryIO, xrange, btou, utob, iteritems, \
+    from .six import MemoryIO, xrange, btou, utob, iteritems, \
         is_str, PY3
-    from fastavro.schema import (
+    from .schema import (
         extract_record_type, acquaint_schema, populate_schema_defs,
         extract_logical_type
     )
@@ -161,20 +160,12 @@ def read_bytes_decimal(data, writer_schema=None, reader_schema=None):
     scale = writer_schema['scale']
     precision = writer_schema['precision']
 
-    tmp = MemoryIO()
-    tmp.write(data)
-
-    tmp.seek(0, SEEK_SET)
-    size = read_long(tmp)
-
-    tmp.seek(0, SEEK_SET)
-
-    datum = read_bytes(tmp)
+    size = len(data)
 
     if PY3:
-        unscaled_datum = read_decimal_from_fixed(datum, precision, scale, size)
+        unscaled_datum = read_decimal_from_fixed(data, precision, scale, size)
     else:
-        unscaled_datum = read_decimal_from_fixed2(datum,
+        unscaled_datum = read_decimal_from_fixed2(data,
                                                   precision, scale, size)
 
     original_prec = getcontext().prec
@@ -188,6 +179,7 @@ def read_decimal_from_fixed(datum, precision, scale, size):
     """
     Decimal is encoded as fixed. Fixed instances are encoded using the
     number of bytes declared in the schema.
+    based on https://github.com/apache/avro/pull/82/
     """
     unscaled_datum = 0
     msb = datum[0]
@@ -211,6 +203,7 @@ def read_decimal_from_fixed2(datum, precision, scale, size):
     """
     Decimal is encoded as fixed. Fixed instances are encoded using the
     number of bytes declared in the schema.
+    based on https://github.com/apache/avro/pull/82/
     """
     unscaled_datum = 0
     msb = struct.unpack('!b', datum[0])[0]

--- a/fastavro/schema.py
+++ b/fastavro/schema.py
@@ -43,11 +43,12 @@ def extract_record_type(schema):
 
 
 def extract_logical_type(schema):
-    if isinstance(schema, dict):
-        rt = extract_record_type(schema)
-        lt = schema.get('logicalType', None)
-        if lt:
-            return rt + "-" + lt
+    if not isinstance(schema, dict):
+        return None
+    rt = extract_record_type(schema)
+    lt = schema.get('logicalType', None)
+    if lt:
+        return rt + "-" + lt
     return None
 
 

--- a/fastavro/schema.py
+++ b/fastavro/schema.py
@@ -42,6 +42,15 @@ def extract_record_type(schema):
     return schema
 
 
+def extract_logical_type(schema):
+    if isinstance(schema, dict):
+        rt = extract_record_type(schema)
+        lt = schema.get('logicalType', None)
+        if lt:
+            return rt + "-" + lt
+    return None
+
+
 def schema_name(schema, parent_ns):
     name = schema.get('name')
     if not name:

--- a/fastavro/six.py
+++ b/fastavro/six.py
@@ -7,14 +7,13 @@ Some of this code is "lifted" from CherryPy.
 import sys
 import json
 from sys import stdout
+from struct import unpack
 
 _encoding = 'UTF-8'
 
-PY3 = False
 if sys.version_info >= (3, 0):
     from io import BytesIO as MemoryIO
     xrange = range
-    PY3 = True
     def py3_btou(n, encoding=_encoding):
         return n.decode(encoding)
 
@@ -32,6 +31,12 @@ if sys.version_info >= (3, 0):
 
     def py3_mk_bits(bits):
         return bytes([bits & 0xff])
+
+    def py3_identity(datum):
+        return datum
+
+    def py3_fstint(datum):
+        return datum[0]
 
 else:  # Python 2x
     from cStringIO import StringIO as MemoryIO  # flake8: noqa
@@ -56,6 +61,13 @@ else:  # Python 2x
 
     def py2_mk_bits(bits):
         return chr(bits & 0xff)
+
+    def py2_str2ints(datum):
+        return map(lambda x:ord(x), datum)
+
+    def py2_fstint(datum):
+        return unpack('!b', datum[0])[0]
+
 # We do it this way and not just redifine function since Cython do not like it
 if sys.version_info >= (3, 0):
     btou = py3_btou
@@ -65,6 +77,8 @@ if sys.version_info >= (3, 0):
     iteritems = py3_iteritems
     is_str = py3_is_str
     mk_bits = py3_mk_bits
+    str2ints = py3_identity
+    fstint = py3_fstint
 else:
     btou = py2_btou
     utob = py2_utob
@@ -73,3 +87,5 @@ else:
     long = long
     is_str = py2_is_str
     mk_bits = py2_mk_bits
+    str2ints = py2_str2ints
+    fstint = py2_fstint

--- a/fastavro/six.py
+++ b/fastavro/six.py
@@ -10,10 +10,11 @@ from sys import stdout
 
 _encoding = 'UTF-8'
 
+PY3 = False
 if sys.version_info >= (3, 0):
     from io import BytesIO as MemoryIO
     xrange = range
-
+    PY3 = True
     def py3_btou(n, encoding=_encoding):
         return n.decode(encoding)
 

--- a/fastavro/six.py
+++ b/fastavro/six.py
@@ -30,6 +30,9 @@ if sys.version_info >= (3, 0):
     def py3_is_str(obj):
         return isinstance(obj, (bytes, str,))
 
+    def py3_mk_bits(bits):
+        return bytes([bits & 0xff])
+
 else:  # Python 2x
     from cStringIO import StringIO as MemoryIO  # flake8: noqa
     xrange = xrange
@@ -51,6 +54,8 @@ else:  # Python 2x
     def py2_is_str(obj):
         return isinstance(obj, basestring) # flake8: noqa
 
+    def py2_mk_bits(bits):
+        return chr(bits & 0xff)
 # We do it this way and not just redifine function since Cython do not like it
 if sys.version_info >= (3, 0):
     btou = py3_btou
@@ -59,6 +64,7 @@ if sys.version_info >= (3, 0):
     long = int
     iteritems = py3_iteritems
     is_str = py3_is_str
+    mk_bits = py3_mk_bits
 else:
     btou = py2_btou
     utob = py2_utob
@@ -66,3 +72,4 @@ else:
     iteritems = py2_iteritems
     long = long
     is_str = py2_is_str
+    mk_bits = py2_mk_bits

--- a/fastavro/writer.py
+++ b/fastavro/writer.py
@@ -22,6 +22,7 @@ except ImportError:
     from fastavro.schema import extract_named_schemas_into_repo,\
         extract_record_type
 
+import datetime
 try:
     import simplejson as json
 except ImportError:
@@ -184,15 +185,16 @@ def validate(datum, schema):
         return isinstance(datum, bytes)
 
     if record_type == 'int':
-        return (
-            isinstance(datum, (int, long,)) and
-            INT_MIN_VALUE <= datum <= INT_MAX_VALUE
-        )
+        return (isinstance(datum, datetime.date) or
+                (isinstance(datum, (int, long,)) and
+                INT_MIN_VALUE <= datum <= INT_MAX_VALUE)
+                )
 
     if record_type == 'long':
         return (
-            isinstance(datum, (int, long,)) and
-            LONG_MIN_VALUE <= datum <= LONG_MAX_VALUE
+            isinstance(datum, datetime.datetime) or
+            (isinstance(datum, (int, long,)) and
+             LONG_MIN_VALUE <= datum <= LONG_MAX_VALUE)
         )
 
     if record_type in ['float', 'double']:

--- a/fastavro/writer.py
+++ b/fastavro/writer.py
@@ -7,6 +7,11 @@
 # Apache 2.0 license (http://www.apache.org/licenses/LICENSE-2.0)
 
 try:
+    from UserDict import UserDict
+except ImportError:
+    from collections import UserDict
+
+try:
     from fastavro._six import utob, MemoryIO, long, is_str, iteritems
     from fastavro._reader import HEADER_SCHEMA, SYNC_SIZE, MAGIC
     from fastavro._schema import extract_named_schemas_into_repo,\
@@ -22,6 +27,7 @@ try:
 except ImportError:
     import json
 
+import time
 from binascii import crc32
 from collections import Iterable, Mapping
 from os import urandom, SEEK_SET
@@ -40,6 +46,23 @@ def write_boolean(fo, datum, schema=None):
     """A boolean is written as a single byte whose value is either 0 (false) or
     1 (true)."""
     fo.write(pack('B', 1 if datum else 0))
+
+
+def write_timestamp_millis(fo, datum, schema=None):
+    t = int(time.mktime(datum.timetuple())) * 1000 + int(
+        datum.microsecond / 1000)
+    write_int(fo, t, schema)
+    # write_int(fo, int(datum.timestamp() * 1000), schema)
+
+
+def write_timestamp_micros(fo, datum, schema=None):
+    t = int(time.mktime(datum.timetuple())) * 1000000 + datum.microsecond
+    write_int(fo, t, schema)
+    # write_int(fo, int(datum.timestamp() * 1000000), schema)
+
+
+def write_date(fo, datum, schema=None):
+    write_int(fo, datum.toordinal(), schema)
 
 
 def write_int(fo, datum, schema=None):
@@ -264,7 +287,33 @@ def write_record(fo, datum, schema):
             name, field.get('default')), field['type'])
 
 
-WRITERS = {
+LOGICALWRITERS = {
+    'long-timestamp-millis': write_timestamp_millis,
+    'long-timestamp-micros': write_timestamp_micros,
+    'int-date': write_date
+}
+
+
+class Writers(UserDict):
+    def __getitem__(self, key):
+        rt = extract_record_type(key)
+        if rt == 'record':
+            return self.data[rt]
+        try:
+            return self.data.__getitem__(key)
+        except:
+            pass
+        if isinstance(key, dict):
+            if "logicalType" not in key:
+                return self.data[rt]
+            return LOGICALWRITERS[key['type'] + "-" + key['logicalType']]
+        if isinstance(key, list):
+            return self.data['union']
+
+
+WRITERS = Writers()
+
+WRITERS.update({
     'null': write_null,
     'boolean': write_boolean,
     'string': write_utf8,
@@ -281,7 +330,7 @@ WRITERS = {
     'error_union': write_union,
     'record': write_record,
     'error': write_record,
-}
+})
 
 _base_types = [
     'boolean',
@@ -309,7 +358,8 @@ def write_data(fo, datum, schema):
     schema: dict
         Schemda to use
     """
-    return WRITERS[extract_record_type(schema)](fo, datum, schema)
+    fn = WRITERS[schema]
+    return fn(fo, datum, schema)
 
 
 def write_header(fo, metadata, sync_marker):

--- a/fastavro/writer.py
+++ b/fastavro/writer.py
@@ -78,7 +78,12 @@ def write_bytes_decimal(data, schema):
     for digit in digits:
         unscaled_datum = (unscaled_datum * 10) + digit
 
-    bits_req = unscaled_datum.bit_length() + 1
+    # 2.6 support
+    if not hasattr(unscaled_datum, 'bit_length'):
+        bits_req = len(bin(abs(unscaled_datum))) - 2
+    else:
+        bits_req = unscaled_datum.bit_length() + 1
+
     if sign:
         unscaled_datum = (1 << bits_req) - unscaled_datum
 

--- a/fastavro/writer.py
+++ b/fastavro/writer.py
@@ -7,14 +7,14 @@
 # Apache 2.0 license (http://www.apache.org/licenses/LICENSE-2.0)
 
 try:
-    from fastavro._six import utob, MemoryIO, long, is_str, iteritems, PY3
-    from fastavro._reader import HEADER_SCHEMA, SYNC_SIZE, MAGIC
-    from fastavro._schema import extract_named_schemas_into_repo,\
+    from ._six import utob, MemoryIO, long, is_str, iteritems, PY3
+    from ._reader import HEADER_SCHEMA, SYNC_SIZE, MAGIC
+    from ._schema import extract_named_schemas_into_repo,\
         extract_record_type, extract_logical_type
 except ImportError:
-    from fastavro.six import utob, MemoryIO, long, is_str, iteritems, PY3
-    from fastavro.reader import HEADER_SCHEMA, SYNC_SIZE, MAGIC
-    from fastavro.schema import extract_named_schemas_into_repo,\
+    from .six import utob, MemoryIO, long, is_str, iteritems, PY3
+    from .reader import HEADER_SCHEMA, SYNC_SIZE, MAGIC
+    from .schema import extract_named_schemas_into_repo,\
         extract_record_type, extract_logical_type
 
 
@@ -63,7 +63,8 @@ def write_date(data, schema):
 
 def write_bytes_decimal(data, schema):
     scale = schema['scale']
-    # pprecision = schema['precision']
+
+    # based on https://github.com/apache/avro/pull/82/
 
     sign, digits, exp = data.as_tuple()
 
@@ -95,7 +96,6 @@ def write_bytes_decimal(data, schema):
 
     tmp = MemoryIO()
 
-    write_long(tmp, bytes_req)
     for index in range(bytes_req - 1, -1, -1):
         bits_to_write = packed_bits >> (8 * index)
         if PY3:

--- a/tests/test_logical_types.py
+++ b/tests/test_logical_types.py
@@ -1,7 +1,9 @@
 import datetime
+from decimal import Decimal
 from io import BytesIO
 
 import fastavro
+from nose.tools import raises
 
 schema = {
     "fields": [
@@ -76,4 +78,24 @@ def test_null():
     assert (data2['date'] is None)
 
 
-test_null()
+schema_top = {
+    "name": "n",
+    "namespace": "namespace",
+    "type": "bytes",
+    "logicalType": "decimal",
+    "precision": 15,
+    "scale": 3,
+}
+
+
+def test_top():
+    data1 = Decimal("123.456")
+    binary = serialize(schema_top, data1)
+    data2 = deserialize(schema_top, binary)
+    assert (data1 == data2)
+
+
+@raises(AssertionError)
+def test_scale():
+    data1 = Decimal("123.456678")  # does not fit scale
+    serialize(schema_top, data1)

--- a/tests/test_logical_types.py
+++ b/tests/test_logical_types.py
@@ -1,0 +1,57 @@
+import datetime
+from io import BytesIO
+
+import fastavro
+
+schema = {
+    "fields": [
+        {
+            "name": "date",
+            "type": {'type': 'int', 'logicalType': 'date'}
+        },
+        {
+            "name": "timestamp-millis",
+            "type": {'type': 'long', 'logicalType': 'timestamp-millis'}
+        },
+        {
+            "name": "timestamp-micros",
+            "type": {'type': 'long', 'logicalType': 'timestamp-micros'}
+        },
+    ],
+    "namespace": "namespace",
+    "name": "name",
+    "type": "record"
+}
+
+
+def serialize(schema, data):
+    bytes_writer = BytesIO()
+    fastavro.schemaless_writer(bytes_writer, schema, data)
+    return bytes_writer.getvalue()
+
+
+def deserialize(schema, binary):
+    bytes_writer = BytesIO()
+    bytes_writer.write(binary)
+    bytes_writer.seek(0)
+
+    res = fastavro.schemaless_reader(bytes_writer, schema)
+    return res
+
+
+def test_logical_types():
+    data1 = {
+        'date': datetime.date.today(),
+        'timestamp-millis': datetime.datetime.now(),
+        'timestamp-micros': datetime.datetime.now(),
+
+    }
+    binary = serialize(schema, data1)
+    data2 = deserialize(schema, binary)
+    assert (data1['date'] == data2['date'])
+    assert (data1['timestamp-micros'] == data2['timestamp-micros'])
+    assert (int(data1['timestamp-millis'].microsecond / 1000) == int(data2[
+        'timestamp-millis'].microsecond))
+
+
+test_logical_types()

--- a/tests/test_logical_types.py
+++ b/tests/test_logical_types.py
@@ -50,8 +50,30 @@ def test_logical_types():
     data2 = deserialize(schema, binary)
     assert (data1['date'] == data2['date'])
     assert (data1['timestamp-micros'] == data2['timestamp-micros'])
-    assert (int(data1['timestamp-millis'].microsecond / 1000) == int(data2[
-        'timestamp-millis'].microsecond))
+    assert (int(data1['timestamp-millis'].microsecond / 1000) ==
+            int(data2['timestamp-millis'].microsecond))
 
 
-test_logical_types()
+schema_null = {
+    "fields": [
+        {
+            "name": "date",
+            "type": ["null", {'type': 'int', 'logicalType': 'date'}]
+        },
+    ],
+    "namespace": "namespace",
+    "name": "name",
+    "type": "record"
+}
+
+
+def test_null():
+    data1 = {
+        # 'date': None,
+    }
+    binary = serialize(schema_null, data1)
+    data2 = deserialize(schema_null, binary)
+    assert (data2['date'] is None)
+
+
+test_null()


### PR DESCRIPTION
date(int), timestamp-millis(long), timestamp-micros(long), decimal(bytes)