### PR TITLE
fix writing unions of bytes or strings on py3

### DIFF
--- a/fastavro/six.py
+++ b/fastavro/six.py
@@ -27,7 +27,7 @@ if sys.version_info >= (3, 0):
         return obj.items()
 
     def py3_is_str(obj):
-        return isinstance(obj, (bytes, str,))
+        return isinstance(obj, str)
 
     def py3_mk_bits(bits):
         return bytes([bits & 0xff])

--- a/tests/test_str_py3.py
+++ b/tests/test_str_py3.py
@@ -5,29 +5,27 @@ from string import ascii_uppercase, digits
 
 import fastavro
 
-letters = ascii_uppercase + digits
-id_size = 100
-
-seed('str_py3')  # Repeatable results
-
-
-def gen_id():
-    return ''.join(choice(letters) for _ in range(id_size))
-
-
-keys = ['first', 'second', 'third', 'fourth']
-
-testdata = [dict((key, gen_id()) for key in keys) for _ in range(50)]
-
-schema = {
-    "fields": [{'name': key, 'type': 'string'} for key in keys],
-    "namespace": "namespace",
-    "name": "zerobyte",
-    "type": "record"
-}
-
 
 def test_str_py3():
+    letters = ascii_uppercase + digits
+    id_size = 100
+
+    seed('str_py3')  # Repeatable results
+
+    def gen_id():
+        return ''.join(choice(letters) for _ in range(id_size))
+
+    keys = ['first', 'second', 'third', 'fourth']
+
+    testdata = [dict((key, gen_id()) for key in keys) for _ in range(50)]
+
+    schema = {
+        "fields": [{'name': key, 'type': 'string'} for key in keys],
+        "namespace": "namespace",
+        "name": "zerobyte",
+        "type": "record"
+    }
+
     buf = BytesIO()
     fastavro.writer(buf, schema, testdata)
 
@@ -41,5 +39,18 @@ def test_str_py3():
     assert rec == testdata[-1], 'bad last record'
 
 
-if __name__ == '__main__':
-    test_str_py3()
+def test_py3_union_string_and_bytes():
+    schema = {
+        "fields": [{'name': 'field', 'type': ['string', 'bytes']}],
+        "namespace": "namespace",
+        "name": "union_string_bytes",
+        "type": "record"
+    }
+
+    records = [
+        {'field': u'string'},
+        {'field': b'bytes'}
+    ]
+
+    buf = BytesIO()
+    fastavro.writer(buf, schema, records)


### PR DESCRIPTION
Without this the test will result in this error:

```
ERROR: test_str_py3.test_py3_union_string_and_bytes
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/scott/.virtualenvs/fastavro/lib/python3.5/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/Users/scott/git/scottbelden/fastavro/tests/test_str_py3.py", line 56, in test_py3_union_string_and_bytes
    fastavro.writer(buf, schema, records)
  File "/Users/scott/git/scottbelden/fastavro/fastavro/writer.py", line 584, in writer
    output.write(record)
  File "/Users/scott/git/scottbelden/fastavro/fastavro/writer.py", line 507, in write
    write_data(self.io, record, self.schema)
  File "/Users/scott/git/scottbelden/fastavro/fastavro/writer.py", line 402, in write_data
    return fn(fo, datum, schema)
  File "/Users/scott/git/scottbelden/fastavro/fastavro/writer.py", line 337, in write_record
    name, field.get('default')), field['type'])
  File "/Users/scott/git/scottbelden/fastavro/fastavro/writer.py", line 402, in write_data
    return fn(fo, datum, schema)
  File "/Users/scott/git/scottbelden/fastavro/fastavro/writer.py", line 323, in write_union
    write_data(fo, datum, schema[index])
  File "/Users/scott/git/scottbelden/fastavro/fastavro/writer.py", line 402, in write_data
    return fn(fo, datum, schema)
  File "/Users/scott/git/scottbelden/fastavro/fastavro/writer.py", line 154, in write_utf8
    write_bytes(fo, utob(datum))
  File "/Users/scott/git/scottbelden/fastavro/fastavro/six.py", line 21, in py3_utob
    return bytes(n, encoding)
TypeError: encoding or errors without a string argument
```

The reason is that in the validator for the unions, when figuring out the correct type, it will check the `string` type and a bytestring will currently pass that validation (https://github.com/tebeka/fastavro/blob/master/fastavro/writer.py#L230-L231). However, it now thinks that `b'bytes'` is a `string` and will eventually call `write_utf8` and `utob` (https://github.com/tebeka/fastavro/blob/master/fastavro/writer.py#L151-L154) which fails.