### PR TITLE
Fix incorrect verification of datetime logical type

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2017-08-1 version 0.14.6
+ * Fix incorrect verification of datetime logical type (@kkirsanov in PR #89)
+
 2017-07-15 version 0.14.5
 * Fix incorrect matching of logical types (@kkirsanov in PR #86)
 

--- a/fastavro/__init__.py
+++ b/fastavro/__init__.py
@@ -43,7 +43,7 @@ The only onterface function is iter_avro, example usage::
         writer(out, schema, records)
 '''
 
-__version_info__ = (0, 14, 5)
+__version_info__ = (0, 14, 6)
 __version__ = '%s.%s.%s' % __version_info__
 
 

--- a/fastavro/writer.py
+++ b/fastavro/writer.py
@@ -234,16 +234,16 @@ def validate(datum, schema):
 
     if record_type == 'int':
         return (
-            isinstance(datum,
-                       (int, long, datetime.time, datetime.datetime)) and
-            INT_MIN_VALUE <= datum <= INT_MAX_VALUE
+            (isinstance(datum, (int, long,)) and
+             INT_MIN_VALUE <= datum <= INT_MAX_VALUE) or
+            isinstance(datum, (datetime.time, datetime.datetime))
         )
 
     if record_type == 'long':
         return (
-            isinstance(datum,
-                       (int, long, datetime.time, datetime.datetime)) and
-            LONG_MIN_VALUE <= datum <= LONG_MAX_VALUE
+            (isinstance(datum, (int, long,)) and
+             INT_MIN_VALUE <= datum <= INT_MAX_VALUE) or
+            isinstance(datum, (datetime.time, datetime.datetime))
         )
 
     if record_type in ['float', 'double']:

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -1,3 +1,4 @@
+import datetime
 from decimal import Decimal
 from io import BytesIO
 
@@ -8,6 +9,11 @@ schema = {
         {
             "name": "array_string",
             "type": {"type": "array", "items": "string"}
+        },
+        {
+            "name": "multi_union_time",
+            "type": ["null", "string", {"type": "long",
+                                        "logicalType": "timestamp-micros"}]
         },
         {
             "name": "array_decimal",
@@ -65,6 +71,7 @@ def test_complex_schema():
     data1 = {
         'array_string': ['a', "b", "c"],
         'array_decimal': [Decimal("123.456")],
+        'multi_union_time': datetime.datetime.now(),
         'array_record': [dict(f1="1", f2=Decimal("123.456"))]
     }
     binary = serialize(schema, data1)


### PR DESCRIPTION
This bug appears when unions are used. Like a {"type": ["null", {"type": "long", "logicalType": "timestamp-micros"}]}
