### PR TITLE
Update writer.py

### DIFF
--- a/fastavro/writer.py
+++ b/fastavro/writer.py
@@ -242,7 +242,7 @@ def validate(datum, schema):
     if record_type == 'long':
         return (
             (isinstance(datum, (int, long,)) and
-             INT_MIN_VALUE <= datum <= INT_MAX_VALUE) or
+             LONG_MIN_VALUE <= datum <= LONG_MAX_VALUE) or
             isinstance(datum, (datetime.time, datetime.datetime))
         )
 

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -773,3 +773,27 @@ def test_is_avro_fo():
             assert fastavro.is_avro(fp)
     with open(__file__, 'rb') as fp:
         assert not fastavro.is_avro(fp)
+
+
+def test_write_long_union_type():
+    schema = {
+        'name': 'test_name',
+        'namespace': 'test',
+        'type': 'record',
+        'fields': [
+            {'name': 'time', 'type': ['null', 'long' ] },
+        ],
+    }
+
+    new_file = MemoryIO()
+    records = [ 
+        { u'time': 809066167221092352},
+    ]
+    try:
+        fastavro.writer(new_file, schema, records)
+    except ValueError:
+        assert False
+    new_file.seek(0)
+    new_reader = fastavro.reader(new_file)
+    new_records = list(new_reader)
+    assert new_records == [  { u'time': 809066167221092352}  ]

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -789,10 +789,7 @@ def test_write_long_union_type():
     records = [
         {u'time': 809066167221092352},
     ]
-    try:
-        fastavro.writer(new_file, schema, records)
-    except ValueError:
-        assert False
+    fastavro.writer(new_file, schema, records)
     new_file.seek(0)
     new_reader = fastavro.reader(new_file)
     new_records = list(new_reader)

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -781,13 +781,13 @@ def test_write_long_union_type():
         'namespace': 'test',
         'type': 'record',
         'fields': [
-            {'name': 'time', 'type': ['null', 'long' ] },
+            {'name': 'time', 'type': ['null', 'long']},
         ],
     }
 
     new_file = MemoryIO()
-    records = [ 
-        { u'time': 809066167221092352},
+    records = [
+        {u'time': 809066167221092352},
     ]
     try:
         fastavro.writer(new_file, schema, records)
@@ -796,4 +796,4 @@ def test_write_long_union_type():
     new_file.seek(0)
     new_reader = fastavro.reader(new_file)
     new_records = list(new_reader)
-    assert new_records == [  { u'time': 809066167221092352}  ]
+    assert new_records == [{u'time': 809066167221092352}]


### PR DESCRIPTION
typo on long validator function using INT constant intead long constants
**Side note**: this behaviour only happens when using write_union function 

Test Case:

```
from fastavro import writer

schema = {
    'doc': 'A weather reading.',
    'name': 'Weather',
    'namespace': 'test',
    'type': 'record',
    'fields': [
        {'name': 'time', 'type': ['null', 'long' ] },
    ],
}

records = [
    { u'time': 1433270389},
    { u'time': 809066167221092352},
]

with open('weather.avro', 'wb') as out:
    writer(out, schema, records)
```