### PR TITLE
Fix deserializing logicalType timestamp-millis millisecond gotcha

### DIFF
--- a/fastavro/reader.py
+++ b/fastavro/reader.py
@@ -141,16 +141,15 @@ def read_boolean(fo, writer_schema=None, reader_schema=None):
 
 
 def parse_timestamp(data, resolution):
-    return datetime.datetime.fromtimestamp(data / resolution).replace(
-        microsecond=data % resolution)
+    return datetime.datetime.fromtimestamp(data / resolution)
 
 
 def read_timestamp_millis(data, writer_schema=None, reader_schema=None):
-    return parse_timestamp(data, 1000)
+    return parse_timestamp(data, 1000.0)
 
 
 def read_timestamp_micros(data, writer_schema=None, reader_schema=None):
-    return parse_timestamp(data, 1000000)
+    return parse_timestamp(data, 1000000.0)
 
 
 def read_date(data, writer_schema=None, reader_schema=None):

--- a/tests/test_logical_types.py
+++ b/tests/test_logical_types.py
@@ -53,8 +53,8 @@ def test_logical_types():
     data2 = deserialize(schema, binary)
     assert (data1['date'] == data2['date'])
     assert (data1['timestamp-micros'] == data2['timestamp-micros'])
-    assert (int(data1['timestamp-millis'].microsecond / 1000) ==
-            int(data2['timestamp-millis'].microsecond))
+    assert (round(data1['timestamp-millis'].microsecond, -3) ==
+            data2['timestamp-millis'].microsecond)
 
 
 def test_not_logical_ints():

--- a/tests/test_logical_types.py
+++ b/tests/test_logical_types.py
@@ -53,8 +53,8 @@ def test_logical_types():
     data2 = deserialize(schema, binary)
     assert (data1['date'] == data2['date'])
     assert (data1['timestamp-micros'] == data2['timestamp-micros'])
-    assert (round(data1['timestamp-millis'].microsecond, -3) ==
-            data2['timestamp-millis'].microsecond)
+    assert (int(data1['timestamp-millis'].microsecond / 1000) * 1000
+            == data2['timestamp-millis'].microsecond)
 
 
 def test_not_logical_ints():


### PR DESCRIPTION
Fix deserializing logicalType timestamp-millis was storing millisecond  inside Python's datatime microsecond property.