### PR TITLE
Add support for Avro aliases

### DIFF
--- a/fastavro/_read.pyx
+++ b/fastavro/_read.pyx
@@ -454,13 +454,21 @@ cpdef read_record(ReaderBase fo, writer_schema, reader_schema=None):
         for field in writer_schema['fields']:
             record[field['name']] = _read_data(fo, field['type'])
     else:
-        readers_field_dict = {f['name']: f for f in reader_schema['fields']}
+        readers_field_dict = {}
+        aliases_field_dict = {}
+        for f in reader_schema['fields']:
+            readers_field_dict[f['name']] = f
+            for alias in f.get('aliases', []):
+                aliases_field_dict[alias] = f
+
         for field in writer_schema['fields']:
             readers_field = readers_field_dict.get(field['name'])
+            if not readers_field:
+                readers_field = aliases_field_dict.get(field['name'])
             if readers_field:
-                record[field['name']] = _read_data(fo,
-                                                   field['type'],
-                                                   readers_field['type'])
+                record[readers_field['name']] = _read_data(fo,
+                                                           field['type'],
+                                                           readers_field['type'])
             else:
                 # should implement skip
                 _read_data(fo, field['type'], field['type'])

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -601,6 +601,56 @@ def test_schema_migration_reader_union():
     assert new_records == records
 
 
+def test_aliases_not_present():
+    schema = {
+        "type": "record",
+        "fields": [{
+            "name": "test",
+            "type": "double"
+        }]
+    }
+
+    new_schema = {
+        "type": "record",
+        "fields": [
+            {"name": "newtest", "type": "double", "aliases": ["testX"]},
+        ]
+    }
+
+    new_file = MemoryIO()
+    records = [{"test": 1.2}]
+    fastavro.writer(new_file, schema, records)
+    new_file.seek(0)
+    reader = fastavro.reader(new_file, new_schema)
+    with pytest.raises(fastavro.read.SchemaResolutionError):
+        list(reader)
+
+
+def test_incompatible_aliases():
+    schema = {
+        "type": "record",
+        "fields": [{
+            "name": "test",
+            "type": "double"
+        }]
+    }
+
+    new_schema = {
+        "type": "record",
+        "fields": [
+            {"name": "newtest", "type": "int", "aliases": ["test"]},
+        ]
+    }
+
+    new_file = MemoryIO()
+    records = [{"test": 1.2}]
+    fastavro.writer(new_file, schema, records)
+    new_file.seek(0)
+    reader = fastavro.reader(new_file, new_schema)
+    with pytest.raises(fastavro.read.SchemaResolutionError):
+        list(reader)
+
+
 def test_schema_migration_union_failure():
     schema = {
         "type": "record",
@@ -737,6 +787,33 @@ def test_schema_migration_schema_mismatch():
     new_reader = fastavro.reader(new_file, new_schema)
     with pytest.raises(fastavro.read.SchemaResolutionError):
         list(new_reader)
+
+
+def test_aliases_in_reader_schema():
+    schema = {
+        "type": "record",
+        "fields": [{
+            "name": "test",
+            "type": "int"
+        }]
+    }
+
+    new_schema = {
+        "type": "record",
+        "fields": [{
+            "name": "newtest",
+            "type": "int",
+            "aliases": ["test"]
+        }]
+    }
+
+    new_file = MemoryIO()
+    records = [{"test": 1}]
+    fastavro.writer(new_file, schema, records)
+    new_file.seek(0)
+    new_reader = fastavro.reader(new_file, new_schema)
+    new_records = list(new_reader)
+    assert new_records[0]["newtest"] == records[0]["test"]
 
 
 def test_empty():


### PR DESCRIPTION
Aliases allow a writer field to have a different name than the reader
field. Potentially, there may be multiple reader fields pointing to the
same writer field, and this is the biggest difficulty to implement
aliases. Fields are read only once from file, but they may need to be
validated multiple times. Files may be read only once because we do not
support "seek()" statements.

The approach we chose was to create a file reader with a cache. A
potential issue with this is for aliased fields that take a lot of
space. We try to mitigate this issue by resorting to in-memory storage
as infrequently as possible.

This should close issue #87.

EDIT: we no longer try to handle the case when multiple reader fields point to the same writer field.