### PR TITLE
add appveyor testing for windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+branches:
+    only:
+        - master
+
+environment:
+    matrix:
+        - PYTHON: "C:\\Python27-x64"
+        # Can't build on 3.4 due to https://github.com/appveyor/ci/issues/1699
+        # and/or https://github.com/appveyor/ci/issues/968
+        # - PYTHON: "C:\\Python34-x64"
+        - PYTHON: "C:\\Python35-x64"
+        - PYTHON: "C:\\Python36-x64"
+
+install:
+    - "%PYTHON%\\python.exe -m pip install pytest flake8 check-manifest Cython"
+
+build: off
+
+test_script:
+    - "set PYTHONPATH=%cd%"
+    - "%PYTHON%\\python.exe setup.py build_ext --inplace"
+    - "%PYTHON%\\python.exe -m pytest -v tests"

--- a/fastavro/_reader.pyx
+++ b/fastavro/_reader.pyx
@@ -208,11 +208,13 @@ cpdef _read_decimal(data, size, writer_schema):
     return scaled_datum
 
 
-cpdef long read_long(ReaderBase fo, writer_schema=None, reader_schema=None) except? -1:
+cpdef long long read_long(ReaderBase fo,
+                          writer_schema=None,
+                          reader_schema=None) except? -1:
     """int and long values are written using variable-length, zig-zag
     coding."""
-    cdef unsigned long b
-    cdef long n
+    cdef unsigned long long b
+    cdef long long n
     cdef int shift
     cdef bytes c = fo.read(1)
 
@@ -291,8 +293,8 @@ cpdef read_double(ReaderBase fo, writer_schema=None, reader_schema=None):
 
 cpdef read_bytes(ReaderBase fo, writer_schema=None, reader_schema=None):
     """Bytes are encoded as a long followed by that many bytes of data."""
-    cdef long size = read_long(fo)
-    return fo.read(size)
+    cdef long long size = read_long(fo)
+    return fo.read(<long>size)
 
 
 cpdef unicode read_utf8(ReaderBase fo, writer_schema=None, reader_schema=None):
@@ -333,7 +335,8 @@ cpdef read_array(ReaderBase fo, writer_schema, reader_schema=None):
     count in this case is the absolute value of the count written.
     """
     cdef list read_items
-    cdef long block_count, i
+    cdef long long block_count
+    cdef long i
 
     read_items = []
 
@@ -370,7 +373,8 @@ cpdef read_map(ReaderBase fo, writer_schema, reader_schema=None):
     count in this case is the absolute value of the count written.
     """
     cdef dict read_items
-    cdef long block_count, i
+    cdef long long block_count
+    cdef long i
     cdef unicode key
 
     read_items = {}

--- a/fastavro/_writer.pyx
+++ b/fastavro/_writer.pyx
@@ -196,7 +196,7 @@ cpdef prepare_fixed_decimal(object data, schema):
 cpdef inline write_int(bytearray fo, datum, schema=None):
     """int and long values are written using variable-length, zig-zag coding.
     """
-    cdef unsigned long n
+    cdef unsigned long long n
     cdef unsigned char ch_temp[1]
     n = (datum << 1) ^ (datum >> 63)
     while (n & ~0x7F) != 0:
@@ -234,7 +234,7 @@ cpdef inline write_float(bytearray fo, float datum, schema=None):
 
 cdef union double_long:
     double d
-    unsigned long n
+    unsigned long long n
 
 
 cpdef inline write_double(bytearray fo, double datum, schema=None):

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -13,7 +13,7 @@ echo "running flake8"
 flake8 fastavro tests
 flake8 --config=.flake8.cython fastavro
 
-check-manifest  --ignore 'fastavro/_*.c'
+check-manifest
 
 # Build Cython modules
 python setup.py build_ext --inplace

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[check-manifest]
+ignore =
+    .travis.yml
+    appveyor.yml

--- a/tests/test_logical_types.py
+++ b/tests/test_logical_types.py
@@ -6,6 +6,8 @@ from decimal import Decimal
 from io import BytesIO
 from uuid import uuid4
 import datetime
+import sys
+import os
 
 
 schema = {
@@ -76,6 +78,8 @@ def test_logical_types():
             == data2['time-millis'].microsecond)
 
 
+@pytest.mark.skipif(os.name == 'nt' and sys.version_info[:2] == (3, 6),
+                    reason='Python Bug: https://bugs.python.org/issue29097')
 def test_not_logical_ints():
     data1 = {
         'date': 1,


### PR DESCRIPTION
Resolves https://github.com/tebeka/fastavro/issues/125
Resolves https://github.com/tebeka/fastavro/issues/126

@barrywhart I needed to change some of the `long`s to `long long` as it seems that for windows a `long` is only 4 bytes whereas on linux it is 8 bytes (which was causing some tests to fail on windows). I wasn't sure if this was the best approach and thought you might have more experience here.