### PR TITLE
Speed up timestamp writes

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+import datetime
 import time
 
 from fastavro import writer, reader
@@ -86,6 +87,19 @@ big_schema = {
     }]
 }
 
+timestamp_schema = {
+    "fields": [
+        {
+            "name": "timestamp-micros",
+            "type": {'type': 'long', 'logicalType': 'timestamp-micros'}
+        },
+    ],
+    "namespace": "namespace",
+    "name": "name",
+    "type": "record"
+}
+
+
 small_record = {'field': 'foo'}
 big_record = {
     'username': 'username',
@@ -100,6 +114,10 @@ big_record = {
         'zip': 'zip',
     },
 }
+timestamp_record = {
+    'timestamp-micros': datetime.datetime.now(),
+
+}
 
 # Configuration is a tuple of (schema, single_record, num_records, num_runs)
 configurations = [
@@ -109,6 +127,7 @@ configurations = [
     (big_schema, big_record, 1, 100000),
     (big_schema, big_record, 100, 1000),
     (big_schema, big_record, 10000, 10),
+    (timestamp_schema, timestamp_record, 100000, 10),
 ]
 
 for schema, single_record, num_records, num_runs in configurations:

--- a/fastavro/_writer.pyx
+++ b/fastavro/_writer.pyx
@@ -82,9 +82,9 @@ cpdef long64 prepare_timestamp_millis(object data, schema):
             time_tuple.tm_isdst = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 8)))
 
             return mktime(& time_tuple) * MLS_PER_SECOND + <long64>(
-                data.microsecond / 1000)
+                data.microsecond) / 1000
         else:
-            return <long64>(data.timestamp() * MLS_PER_SECOND)
+            return <long64>(<double>(data.timestamp()) * MLS_PER_SECOND)
     else:
         return data
 
@@ -105,7 +105,7 @@ cpdef long64 prepare_timestamp_micros(object data, schema):
             time_tuple.tm_isdst = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 8)))
             return mktime(& time_tuple) * MCS_PER_SECOND + data.microsecond
         else:
-            return <long64>(data.timestamp() * MCS_PER_SECOND)
+            return <long64>(<double>(data.timestamp()) * MCS_PER_SECOND)
     else:
         return data
 

--- a/fastavro/_writer.pyx
+++ b/fastavro/_writer.pyx
@@ -25,6 +25,10 @@ import time
 from binascii import crc32
 from collections import Iterable, Mapping
 from libc.time cimport tm, mktime
+from cpython.datetime cimport (
+    PyDateTime_GET_YEAR, PyDateTime_GET_MONTH, PyDateTime_GET_DAY,
+    PyDateTime_DATE_GET_HOUR, PyDateTime_DATE_GET_MINUTE,
+    PyDateTime_DATE_GET_SECOND, PyDateTime_DATE_GET_MICROSECOND)
 from cpython.int cimport PyInt_AS_LONG
 from cpython.tuple cimport PyTuple_GET_ITEM
 from libc.string cimport memset
@@ -71,14 +75,13 @@ cpdef long64 prepare_timestamp_millis(object data, schema):
     cdef object tt
     if isinstance(data, datetime.datetime):
         if not has_timestamp_fn:
+            time_tuple.tm_sec = PyDateTime_DATE_GET_SECOND(data)
+            time_tuple.tm_min = PyDateTime_DATE_GET_MINUTE(data)
+            time_tuple.tm_hour = PyDateTime_DATE_GET_HOUR(data)
+            time_tuple.tm_mday = PyDateTime_GET_DAY(data)
+            time_tuple.tm_mon = PyDateTime_GET_MONTH(data) - 1
+            time_tuple.tm_year = PyDateTime_GET_YEAR(data) - 1900
             tt = data.timetuple()
-            memset(& time_tuple, 0, sizeof(tm))
-            time_tuple.tm_sec = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 5)))
-            time_tuple.tm_min = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 4)))
-            time_tuple.tm_hour = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 3)))
-            time_tuple.tm_mday = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 2)))
-            time_tuple.tm_mon = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 1))) - 1
-            time_tuple.tm_year = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 0))) - 1900
             time_tuple.tm_isdst = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 8)))
 
             return mktime(& time_tuple) * MLS_PER_SECOND + <long64>(
@@ -94,15 +97,15 @@ cpdef long64 prepare_timestamp_micros(object data, schema):
     cdef object tt
     if isinstance(data, datetime.datetime):
         if not has_timestamp_fn:
+            time_tuple.tm_sec = PyDateTime_DATE_GET_SECOND(data)
+            time_tuple.tm_min = PyDateTime_DATE_GET_MINUTE(data)
+            time_tuple.tm_hour = PyDateTime_DATE_GET_HOUR(data)
+            time_tuple.tm_mday = PyDateTime_GET_DAY(data)
+            time_tuple.tm_mon = PyDateTime_GET_MONTH(data) - 1
+            time_tuple.tm_year = PyDateTime_GET_YEAR(data) - 1900
             tt = data.timetuple()
-            memset(& time_tuple, 0, sizeof(tm))
-            time_tuple.tm_sec = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 5)))
-            time_tuple.tm_min = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 4)))
-            time_tuple.tm_hour = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 3)))
-            time_tuple.tm_mday = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 2)))
-            time_tuple.tm_mon = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 1))) - 1
-            time_tuple.tm_year = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 0))) - 1900
             time_tuple.tm_isdst = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 8)))
+
             return mktime(& time_tuple) * MCS_PER_SECOND + data.microsecond
         else:
             return <long64>(<double>(data.timestamp()) * MCS_PER_SECOND)

--- a/fastavro/_writer.pyx
+++ b/fastavro/_writer.pyx
@@ -78,8 +78,6 @@ cpdef long64 prepare_timestamp_millis(object data, schema):
             time_tuple.tm_mday = <int>(<object>(PyTuple_GET_ITEM(tt, 2)))
             time_tuple.tm_mon = <int>(<object>(PyTuple_GET_ITEM(tt, 1))) - 1
             time_tuple.tm_year = <int>(<object>(PyTuple_GET_ITEM(tt, 0))) - 1900
-            time_tuple.tm_wday = <int>(<object>(PyTuple_GET_ITEM(tt, 6)))
-            time_tuple.tm_yday = <int>(<object>(PyTuple_GET_ITEM(tt, 7)))
             time_tuple.tm_isdst = <int>(<object>(PyTuple_GET_ITEM(tt, 8)))
 
             return mktime(& time_tuple) * MLS_PER_SECOND + <long64>(
@@ -103,8 +101,6 @@ cpdef long64 prepare_timestamp_micros(object data, schema):
             time_tuple.tm_mday = <int>(<object>(PyTuple_GET_ITEM(tt, 2)))
             time_tuple.tm_mon = <int>(<object>(PyTuple_GET_ITEM(tt, 1))) - 1
             time_tuple.tm_year = <int>(<object>(PyTuple_GET_ITEM(tt, 0))) - 1900
-            time_tuple.tm_wday = <int>(<object>(PyTuple_GET_ITEM(tt, 6)))
-            time_tuple.tm_yday = <int>(<object>(PyTuple_GET_ITEM(tt, 7)))
             time_tuple.tm_isdst = <int>(<object>(PyTuple_GET_ITEM(tt, 8)))
             return mktime(& time_tuple) * MCS_PER_SECOND + data.microsecond
         else:

--- a/fastavro/_writer.pyx
+++ b/fastavro/_writer.pyx
@@ -25,14 +25,8 @@ import time
 from binascii import crc32
 from collections import Iterable, Mapping
 from libc.time cimport tm, mktime
-from cpython.datetime cimport(
-    PyDateTime_GET_YEAR, PyDateTime_GET_MONTH, PyDateTime_GET_DAY,
-    PyDateTime_DATE_GET_HOUR, PyDateTime_DATE_GET_MINUTE,
-    PyDateTime_DATE_GET_SECOND, PyDateTime_DATE_GET_MICROSECOND)
 from cpython.int cimport PyInt_AS_LONG
-from cpython.method cimport PyMethod_GET_SELF
-from cpython.object cimport PyObject, PyObject_CallObject, PyObject_GetAttrString
-from cpython.tuple cimport PyTuple_GET_ITEM, PyTuple_Pack
+from cpython.tuple cimport PyTuple_GET_ITEM
 from libc.string cimport memset
 from os import urandom, SEEK_SET
 from zlib import compress
@@ -75,19 +69,18 @@ cpdef inline write_boolean(bytearray fo, bint datum, schema=None):
 _EMPTY_TUPLE = tuple()
 
 cpdef long64 prepare_timestamp_millis(object data, schema):
+    cdef object tt
     cdef tm time_tuple
     if isinstance(data, datetime.datetime):
         if not has_timestamp_fn:
-            time_tuple.tm_sec = PyDateTime_DATE_GET_SECOND(data)
-            time_tuple.tm_min = PyDateTime_DATE_GET_MINUTE(data)
-            time_tuple.tm_hour = PyDateTime_DATE_GET_HOUR(data)
-            time_tuple.tm_mday = PyDateTime_GET_DAY(data)
-            time_tuple.tm_mon = PyDateTime_GET_MONTH(data) - 1
-            time_tuple.tm_year = PyDateTime_GET_YEAR(data) - 1900
-            time_tuple.tm_isdst = PyInt_AS_LONG(
-                <object>(PyTuple_GET_ITEM(PyObject_CallObject(
-                    PyObject_GetAttrString(data, 'timetuple'),
-                    _EMPTY_TUPLE), 8)))
+            tt = data.timetuple()
+            time_tuple.tm_sec = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 5)))
+            time_tuple.tm_min = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 4)))
+            time_tuple.tm_hour = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 3)))
+            time_tuple.tm_mday = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 2)))
+            time_tuple.tm_mon = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 1))) - 1
+            time_tuple.tm_year = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 0))) - 1900
+            time_tuple.tm_isdst = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 8)))
 
             return mktime(& time_tuple) * MLS_PER_SECOND + <long64>(
                 data.microsecond) / 1000
@@ -98,19 +91,18 @@ cpdef long64 prepare_timestamp_millis(object data, schema):
 
 
 cpdef long64 prepare_timestamp_micros(object data, schema):
+    cdef object tt
     cdef tm time_tuple
     if isinstance(data, datetime.datetime):
         if not has_timestamp_fn:
-            time_tuple.tm_sec = PyDateTime_DATE_GET_SECOND(data)
-            time_tuple.tm_min = PyDateTime_DATE_GET_MINUTE(data)
-            time_tuple.tm_hour = PyDateTime_DATE_GET_HOUR(data)
-            time_tuple.tm_mday = PyDateTime_GET_DAY(data)
-            time_tuple.tm_mon = PyDateTime_GET_MONTH(data) - 1
-            time_tuple.tm_year = PyDateTime_GET_YEAR(data) - 1900
-            time_tuple.tm_isdst = PyInt_AS_LONG(
-                <object>(PyTuple_GET_ITEM(PyObject_CallObject(
-                    PyObject_GetAttrString(data, 'timetuple'),
-                    _EMPTY_TUPLE), 8)))
+            tt = data.timetuple()
+            time_tuple.tm_sec = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 5)))
+            time_tuple.tm_min = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 4)))
+            time_tuple.tm_hour = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 3)))
+            time_tuple.tm_mday = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 2)))
+            time_tuple.tm_mon = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 1))) - 1
+            time_tuple.tm_year = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 0))) - 1900
+            time_tuple.tm_isdst = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 8)))
 
             return mktime(& time_tuple) * MCS_PER_SECOND + \
                 <long64>(data.microsecond)

--- a/fastavro/_writer.pyx
+++ b/fastavro/_writer.pyx
@@ -25,7 +25,7 @@ import time
 from binascii import crc32
 from collections import Iterable, Mapping
 from libc.time cimport tm, mktime
-from cpython.datetime cimport (
+from cpython.datetime cimport(
     PyDateTime_GET_YEAR, PyDateTime_GET_MONTH, PyDateTime_GET_DAY,
     PyDateTime_DATE_GET_HOUR, PyDateTime_DATE_GET_MINUTE,
     PyDateTime_DATE_GET_SECOND, PyDateTime_DATE_GET_MICROSECOND)

--- a/fastavro/_writer.pyx
+++ b/fastavro/_writer.pyx
@@ -26,6 +26,7 @@ from binascii import crc32
 from collections import Iterable, Mapping
 from libc.time cimport tm, mktime
 from cpython.tuple cimport PyTuple_GET_ITEM
+from libc.string cimport memset
 from os import urandom, SEEK_SET
 from zlib import compress
 
@@ -70,6 +71,7 @@ cpdef long64 prepare_timestamp_millis(object data, schema):
     if isinstance(data, datetime.datetime):
         if not has_timestamp_fn:
             tt = data.timetuple()
+            memset(& time_tuple, 0, sizeof(tm))
             time_tuple.tm_sec = <int>(<object>(PyTuple_GET_ITEM(tt, 5)))
             time_tuple.tm_min = <int>(<object>(PyTuple_GET_ITEM(tt, 4)))
             time_tuple.tm_hour = <int>(<object>(PyTuple_GET_ITEM(tt, 3)))
@@ -79,8 +81,7 @@ cpdef long64 prepare_timestamp_millis(object data, schema):
             time_tuple.tm_wday = <int>(<object>(PyTuple_GET_ITEM(tt, 6)))
             time_tuple.tm_yday = <int>(<object>(PyTuple_GET_ITEM(tt, 7)))
             time_tuple.tm_isdst = <int>(<object>(PyTuple_GET_ITEM(tt, 8)))
-            time_tuple.tm_zone = NULL
-            time_tuple.tm_gmtoff = 0
+
             return mktime(& time_tuple) * MLS_PER_SECOND + <long64>(
                 data.microsecond / 1000)
         else:
@@ -95,6 +96,7 @@ cpdef long64 prepare_timestamp_micros(object data, schema):
     if isinstance(data, datetime.datetime):
         if not has_timestamp_fn:
             tt = data.timetuple()
+            memset(& time_tuple, 0, sizeof(tm))
             time_tuple.tm_sec = <int>(<object>(PyTuple_GET_ITEM(tt, 5)))
             time_tuple.tm_min = <int>(<object>(PyTuple_GET_ITEM(tt, 4)))
             time_tuple.tm_hour = <int>(<object>(PyTuple_GET_ITEM(tt, 3)))
@@ -104,8 +106,6 @@ cpdef long64 prepare_timestamp_micros(object data, schema):
             time_tuple.tm_wday = <int>(<object>(PyTuple_GET_ITEM(tt, 6)))
             time_tuple.tm_yday = <int>(<object>(PyTuple_GET_ITEM(tt, 7)))
             time_tuple.tm_isdst = <int>(<object>(PyTuple_GET_ITEM(tt, 8)))
-            time_tuple.tm_zone = NULL
-            time_tuple.tm_gmtoff = 0
             return mktime(& time_tuple) * MCS_PER_SECOND + data.microsecond
         else:
             return <long>(data.timestamp() * MCS_PER_SECOND)

--- a/fastavro/_writer.pyx
+++ b/fastavro/_writer.pyx
@@ -25,6 +25,7 @@ import time
 from binascii import crc32
 from collections import Iterable, Mapping
 from libc.time cimport tm, mktime
+from cpython.int cimport PyInt_AS_LONG
 from cpython.tuple cimport PyTuple_GET_ITEM
 from libc.string cimport memset
 from os import urandom, SEEK_SET
@@ -72,13 +73,13 @@ cpdef long64 prepare_timestamp_millis(object data, schema):
         if not has_timestamp_fn:
             tt = data.timetuple()
             memset(& time_tuple, 0, sizeof(tm))
-            time_tuple.tm_sec = <int>(<object>(PyTuple_GET_ITEM(tt, 5)))
-            time_tuple.tm_min = <int>(<object>(PyTuple_GET_ITEM(tt, 4)))
-            time_tuple.tm_hour = <int>(<object>(PyTuple_GET_ITEM(tt, 3)))
-            time_tuple.tm_mday = <int>(<object>(PyTuple_GET_ITEM(tt, 2)))
-            time_tuple.tm_mon = <int>(<object>(PyTuple_GET_ITEM(tt, 1))) - 1
-            time_tuple.tm_year = <int>(<object>(PyTuple_GET_ITEM(tt, 0))) - 1900
-            time_tuple.tm_isdst = <int>(<object>(PyTuple_GET_ITEM(tt, 8)))
+            time_tuple.tm_sec = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 5)))
+            time_tuple.tm_min = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 4)))
+            time_tuple.tm_hour = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 3)))
+            time_tuple.tm_mday = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 2)))
+            time_tuple.tm_mon = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 1))) - 1
+            time_tuple.tm_year = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 0))) - 1900
+            time_tuple.tm_isdst = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 8)))
 
             return mktime(& time_tuple) * MLS_PER_SECOND + <long64>(
                 data.microsecond / 1000)
@@ -95,13 +96,13 @@ cpdef long64 prepare_timestamp_micros(object data, schema):
         if not has_timestamp_fn:
             tt = data.timetuple()
             memset(& time_tuple, 0, sizeof(tm))
-            time_tuple.tm_sec = <int>(<object>(PyTuple_GET_ITEM(tt, 5)))
-            time_tuple.tm_min = <int>(<object>(PyTuple_GET_ITEM(tt, 4)))
-            time_tuple.tm_hour = <int>(<object>(PyTuple_GET_ITEM(tt, 3)))
-            time_tuple.tm_mday = <int>(<object>(PyTuple_GET_ITEM(tt, 2)))
-            time_tuple.tm_mon = <int>(<object>(PyTuple_GET_ITEM(tt, 1))) - 1
-            time_tuple.tm_year = <int>(<object>(PyTuple_GET_ITEM(tt, 0))) - 1900
-            time_tuple.tm_isdst = <int>(<object>(PyTuple_GET_ITEM(tt, 8)))
+            time_tuple.tm_sec = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 5)))
+            time_tuple.tm_min = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 4)))
+            time_tuple.tm_hour = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 3)))
+            time_tuple.tm_mday = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 2)))
+            time_tuple.tm_mon = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 1))) - 1
+            time_tuple.tm_year = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 0))) - 1900
+            time_tuple.tm_isdst = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 8)))
             return mktime(& time_tuple) * MCS_PER_SECOND + data.microsecond
         else:
             return <long64>(data.timestamp() * MCS_PER_SECOND)

--- a/fastavro/_writer.pyx
+++ b/fastavro/_writer.pyx
@@ -76,7 +76,7 @@ cpdef long64 prepare_timestamp_millis(object data, schema):
         time_tuple.tm_isdst = <int>(<object>(PyTuple_GET_ITEM(tt, 8)))
         time_tuple.tm_zone = NULL
         time_tuple.tm_gmtoff = 0
-        return mktime( & time_tuple) * MLS_PER_SECOND + <long64>(
+        return mktime(& time_tuple) * MLS_PER_SECOND + <long64>(
             data.microsecond / 1000)
     else:
         return data
@@ -98,7 +98,7 @@ cpdef long64 prepare_timestamp_micros(object data, schema):
         time_tuple.tm_isdst = <int>(<object>(PyTuple_GET_ITEM(tt, 8)))
         time_tuple.tm_zone = NULL
         time_tuple.tm_gmtoff = 0
-        return mktime( & time_tuple) * MCS_PER_SECOND + data.microsecond
+        return mktime(& time_tuple) * MCS_PER_SECOND + data.microsecond
     else:
         return data
 

--- a/fastavro/_writer.pyx
+++ b/fastavro/_writer.pyx
@@ -76,7 +76,7 @@ cpdef long64 prepare_timestamp_millis(object data, schema):
         time_tuple.tm_isdst = <int>(<object>(PyTuple_GET_ITEM(tt, 8)))
         time_tuple.tm_zone = NULL
         time_tuple.tm_gmtoff = 0
-        return mktime(&time_tuple) * MLS_PER_SECOND + <long64>(
+        return mktime( & time_tuple) * MLS_PER_SECOND + <long64>(
             data.microsecond / 1000)
     else:
         return data
@@ -98,7 +98,7 @@ cpdef long64 prepare_timestamp_micros(object data, schema):
         time_tuple.tm_isdst = <int>(<object>(PyTuple_GET_ITEM(tt, 8)))
         time_tuple.tm_zone = NULL
         time_tuple.tm_gmtoff = 0
-        return mktime(&time_tuple) * MCS_PER_SECOND + data.microsecond
+        return mktime( & time_tuple) * MCS_PER_SECOND + data.microsecond
     else:
         return data
 

--- a/fastavro/_writer.pyx
+++ b/fastavro/_writer.pyx
@@ -85,7 +85,7 @@ cpdef long64 prepare_timestamp_millis(object data, schema):
             return mktime(& time_tuple) * MLS_PER_SECOND + <long64>(
                 data.microsecond / 1000)
         else:
-            return <long>(data.timestamp() * MLS_PER_SECOND)
+            return <long64>(data.timestamp() * MLS_PER_SECOND)
     else:
         return data
 
@@ -108,7 +108,7 @@ cpdef long64 prepare_timestamp_micros(object data, schema):
             time_tuple.tm_isdst = <int>(<object>(PyTuple_GET_ITEM(tt, 8)))
             return mktime(& time_tuple) * MCS_PER_SECOND + data.microsecond
         else:
-            return <long>(data.timestamp() * MCS_PER_SECOND)
+            return <long64>(data.timestamp() * MCS_PER_SECOND)
     else:
         return data
 


### PR DESCRIPTION
This PR speeds up writing timestamps.

* Python 2.7-3.2: 10-15%
* Python 3.3 and later: 25-28%

This is a Cython-only improvement; it has no impact on pure Python (i.e. pypy).