### PR TITLE
`fastavro` command-line tool crashes if data contains date or date/time values

### DIFF
--- a/fastavro/__main__.py
+++ b/fastavro/__main__.py
@@ -1,8 +1,23 @@
-import fastavro as avro
-from fastavro.six import json_dump
+import datetime
 from sys import stdout
 
+import fastavro as avro
+from fastavro.six import iteritems, json_dump
+
 encoding = stdout.encoding or "UTF-8"
+
+
+def _clean_json(data):
+    if isinstance(data, dict):
+        for k, v in iteritems(data):
+            if isinstance(v, (datetime.date, datetime.datetime)):
+                data[k] = v.isoformat()
+            else:
+                _clean_json(v)
+    elif isinstance(data, list):
+        for i, v in enumerate(data):
+            if isinstance(v, (datetime.date, datetime.datetime)):
+                data[i] = v.isoformat()
 
 
 def main(argv=None):
@@ -51,6 +66,7 @@ def main(argv=None):
         indent = 4 if args.pretty else None
         try:
             for record in reader:
+                _clean_json(record)
                 json_dump(record, indent)
                 sys.stdout.write('\n')
         except (IOError, KeyboardInterrupt):

--- a/fastavro/__main__.py
+++ b/fastavro/__main__.py
@@ -73,7 +73,7 @@ def main(argv=None):
         indent = 4 if args.pretty else None
         try:
             for record in reader:
-                _clean_json(record)
+                _clean_json_record(record)
                 json_dump(record, indent)
                 sys.stdout.write('\n')
         except (IOError, KeyboardInterrupt):

--- a/fastavro/__main__.py
+++ b/fastavro/__main__.py
@@ -1,5 +1,7 @@
 import datetime
+from decimal import Decimal
 from sys import stdout
+from uuid import UUID
 
 import fastavro as avro
 from fastavro.six import iteritems, json_dump
@@ -7,17 +9,22 @@ from fastavro.six import iteritems, json_dump
 encoding = stdout.encoding or "UTF-8"
 
 
-def _clean_json(data):
+def _clean_json_value(collection, key, value):
+    if isinstance(value, (datetime.date, datetime.datetime)):
+        collection[key] = value.isoformat()
+    elif isinstance(value, (Decimal, UUID)):
+        collection[key] = str(value)
+    else:
+        _clean_json(value)
+
+
+def _clean_json_record(data):
     if isinstance(data, dict):
         for k, v in iteritems(data):
-            if isinstance(v, (datetime.date, datetime.datetime)):
-                data[k] = v.isoformat()
-            else:
-                _clean_json(v)
+            _clean_json_value(data, k, v)
     elif isinstance(data, list):
         for i, v in enumerate(data):
-            if isinstance(v, (datetime.date, datetime.datetime)):
-                data[i] = v.isoformat()
+            _clean_json_value(data, i, v)
 
 
 def main(argv=None):

--- a/fastavro/__main__.py
+++ b/fastavro/__main__.py
@@ -15,7 +15,7 @@ def _clean_json_value(collection, key, value):
     elif isinstance(value, (Decimal, UUID)):
         collection[key] = str(value)
     else:
-        _clean_json(value)
+        _clean_json_record(value)
 
 
 def _clean_json_record(data):

--- a/fastavro/_six.pyx
+++ b/fastavro/_six.pyx
@@ -29,7 +29,10 @@ if sys.version_info >= (3, 0):
         return bytes(n, encoding)
 
     def py3_json_dump(obj, indent):
-        json.dump(obj, stdout, indent=indent)
+        if _HAS_UJSON:
+            json.dump(obj, stdout, indent=indent)
+        else:
+            json.dump(obj, stdout, indent=indent, encoding=_outenc)
 
     def py3_iterkeys(obj):
         return obj.keys()

--- a/fastavro/six.py
+++ b/fastavro/six.py
@@ -65,10 +65,13 @@ else:  # Python 2x
     _outenc = getattr(stdout, 'encoding', None) or _encoding
 
     def py2_json_dump(obj, indent):
+        kwargs = {}
+        if indent is not None:
+            kwargs['indent'] = indent
         if _HAS_UJSON:
-            json.dump(obj, stdout, indent=indent)
+            json.dump(obj, stdout, **kwargs)
         else:
-            json.dump(obj, stdout, indent=indent, encoding=_outenc)
+            json.dump(obj, stdout, encoding=_outenc, **kwargs)
 
     def py2_iterkeys(obj):
         return obj.iterkeys()

--- a/fastavro/six.py
+++ b/fastavro/six.py
@@ -29,7 +29,10 @@ if sys.version_info >= (3, 0):
         return bytes(n, encoding)
 
     def py3_json_dump(obj, indent):
-        json.dump(obj, stdout, indent=indent)
+        if _HAS_UJSON:
+            json.dump(obj, stdout, indent=indent)
+        else:
+            json.dump(obj, stdout, indent=indent, encoding=_outenc)
 
     def py3_iterkeys(obj):
         return obj.keys()

--- a/tests/test_logical_types.py
+++ b/tests/test_logical_types.py
@@ -1,5 +1,5 @@
 import fastavro
-from fastavro.__main__ import _clean_json_value, _clean_json_record
+from fastavro.__main__ import _clean_json_record
 import pytest
 
 from decimal import Decimal

--- a/tests/test_logical_types.py
+++ b/tests/test_logical_types.py
@@ -10,7 +10,6 @@ import sys
 import os
 
 
-
 schema = {
     "fields": [
         {
@@ -249,7 +248,10 @@ def test_fixed_decimal_binary():
 
 def test_clean_json_list():
     values = [
-        datetime.datetime.now(), datetime.date.today(), uuid4(), Decimal('1.23')
+        datetime.datetime.now(),
+        datetime.date.today(),
+        uuid4(),
+        Decimal('1.23'),
     ]
     str_values = [
         values[0].isoformat(),
@@ -266,7 +268,7 @@ def test_clean_json_dict():
         '1': datetime.datetime.now(),
         '2': datetime.date.today(),
         '3': uuid4(),
-        '4': Decimal('1.23')
+        '4': Decimal('1.23'),
     }
     str_values = {
         '1': values['1'].isoformat(),

--- a/tests/test_logical_types.py
+++ b/tests/test_logical_types.py
@@ -1,5 +1,5 @@
 import fastavro
-
+from fastavro.__main__ import _clean_json_value, _clean_json_record
 import pytest
 
 from decimal import Decimal
@@ -8,6 +8,7 @@ from uuid import uuid4
 import datetime
 import sys
 import os
+
 
 
 schema = {
@@ -244,3 +245,34 @@ def test_fixed_decimal_binary():
                        b'\xFF\xFF\xFF\xFF\xFF\xd5F\x80')
     data2 = deserialize(schema_fixed_decimal_leftmost, binary)
     assert (Decimal("-2.80") == data2)
+
+
+def test_clean_json_list():
+    values = [
+        datetime.datetime.now(), datetime.date.today(), uuid4(), Decimal('1.23')
+    ]
+    str_values = [
+        values[0].isoformat(),
+        values[1].isoformat(),
+        str(values[2]),
+        str(values[3]),
+    ]
+    _clean_json_record(values)
+    assert values == str_values
+
+
+def test_clean_json_dict():
+    values = {
+        '1': datetime.datetime.now(),
+        '2': datetime.date.today(),
+        '3': uuid4(),
+        '4': Decimal('1.23')
+    }
+    str_values = {
+        '1': values['1'].isoformat(),
+        '2': values['2'].isoformat(),
+        '3': str(values['3']),
+        '4': str(values['4']),
+    }
+    _clean_json_record(values)
+    assert values == str_values


### PR DESCRIPTION
This fixes a bug I noticed with the `fastavro` command-line tool dumping an Avro file: If `ujson` is not installed (i.e. if using the built-in `json` module), dumping an Avro file with any of the higher-level logical (Python) types crashes:
* `datetime`
* `date`
* `Decimal`
* `UUID`

This occurs because `json.dumps()` does not support those data types.

I fixed this by scanning each record after it is read but before it is dumped, converting those values to strings. I'm not sure there is a perfect fix here, but this seems reasonable.

Here's an example stack trace of the failure with a `datetime` value:
```
  File "/Users/bhart/.pyenv/versions/fastavro-2.7.13/bin/fastavro", line 11, in <module>
    load_entry_point('fastavro', 'console_scripts', 'fastavro')()
  File "/Users/bhart/dev/fastavro/fastavro/__main__.py", line 54, in main
    json_dump(record, indent)
  File "/Users/bhart/dev/fastavro/fastavro/six.py", line 71, in py2_json_dump
    json.dump(obj, stdout, indent=indent, encoding=_outenc)
  File "/Users/bhart/.pyenv/versions/2.7.13/lib/python2.7/json/__init__.py", line 189, in dump
    for chunk in iterable:
  File "/Users/bhart/.pyenv/versions/2.7.13/lib/python2.7/json/encoder.py", line 434, in _iterencode
    for chunk in _iterencode_dict(o, _current_indent_level):
  File "/Users/bhart/.pyenv/versions/2.7.13/lib/python2.7/json/encoder.py", line 408, in _iterencode_dict
    for chunk in chunks:
  File "/Users/bhart/.pyenv/versions/2.7.13/lib/python2.7/json/encoder.py", line 442, in _iterencode
    o = _default(o)
  File "/Users/bhart/.pyenv/versions/2.7.13/lib/python2.7/json/encoder.py", line 184, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: datetime.datetime(2017, 12, 24, 23, 56, 23) is not JSON serializable
```