### PR TITLE
Handle records and maps that are OrderedDict rather than dict

### DIFF
--- a/fastavro/_write.pyx
+++ b/fastavro/_write.pyx
@@ -393,7 +393,6 @@ cpdef write_map(bytearray fo, object datum, dict schema):
         write_long(fo, 0)
 
 
-
 INT_MIN_VALUE = -(1 << 31)
 INT_MAX_VALUE = (1 << 31) - 1
 LONG_MIN_VALUE = -(1 << 63)

--- a/fastavro/_write.pyx
+++ b/fastavro/_write.pyx
@@ -387,7 +387,7 @@ cpdef write_map(bytearray fo, object datum, dict schema):
         # data. In this case, bail out so we don't possibly corrupt the output
         # file.
         if d_datum is not None:
-            raise
+            raise  # re-raise where d_datum is not None
 
         # Slower, general-purpose code where datum is something besides a dict,
         # e.g. a collections.OrderedDict or collections.defaultdict.

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -7,6 +7,7 @@ from fastavro.six import MemoryIO
 import pytest
 
 import sys
+from collections import OrderedDict
 from os.path import join, abspath, dirname, basename
 from glob import iglob
 
@@ -1059,6 +1060,35 @@ def test_dump_load(tmpdir):
         ]
     }
     record = {"field": "foobar"}
+
+    temp_path = tmpdir.join('test_dump.avro')
+    with temp_path.open('wb') as fo:
+        fastavro.dump(fo, record, schema)
+
+    with temp_path.open('rb') as fo:
+        new_record = fastavro.load(fo, schema)
+
+    assert record == new_record
+
+
+def test_ordered_dict(tmpdir):
+    """
+    Write an Avro record to a file using the dump() function and loads it back
+    using the load() function.
+    """
+    schema = {
+        "type": "record",
+        "name": "Test",
+        "namespace": "test",
+        "fields": [
+            {
+                "name": "field",
+                "type": {"type": "string"}
+            }
+        ]
+    }
+    record = OrderedDict()
+    record["field"] = "foobar"
 
     temp_path = tmpdir.join('test_dump.avro')
     with temp_path.open('wb') as fo:

--- a/tests/test_fastavro.py
+++ b/tests/test_fastavro.py
@@ -1151,16 +1151,17 @@ def test_regular_vs_ordered_dict_record_typeerror():
     }
 
     # Test with two different bad records. One is a regular dict, and the other
-    # is an OrderedDict. Both have a bad value (string where the schema declares
-    # an int).
+    # is an OrderedDict. Both have a bad value (string where the schema
+    # declares an int).
     test_records = [{'field': 'foobar'}]
     record = OrderedDict()
     record["field"] = "foobar"
     test_records.append(record)
 
     expected_write_record_stack_traces = [
-        # For the regular dict, fails by reraising an error accessing 'd_datum',
-        # a variable that only gets a value if the record is an actual dict.
+        # For the regular dict, fails by reraising an error accessing
+        # 'd_datum', a variable that only gets a value if the record is an
+        # actual dict.
         [
             'cpdef write_record(bytearray fo, object datum, dict schema):',
             'raise',
@@ -1212,16 +1213,17 @@ def test_regular_vs_ordered_dict_map_typeerror():
     }
 
     # Test with two different bad records. One is a regular dict, and the other
-    # is an OrderedDict. Both have a bad value (string where the schema declares
-    # an int).
+    # is an OrderedDict. Both have a bad value (string where the schema
+    # declares an int).
     test_records = [{'test': {'foo': 'bar'}}]
     map_ = OrderedDict()
     map_["foo"] = "bar"
     test_records.append({'test': map_})
 
     expected_write_record_stack_traces = [
-        # For the regular dict, fails by reraising an error accessing 'd_datum',
-        # a variable that only gets a value if the record is an actual dict.
+        # For the regular dict, fails by reraising an error accessing
+        # 'd_datum', a variable that only gets a value if the record is an
+        # actual dict.
         [
             'cpdef write_map(bytearray fo, object datum, dict schema):',
             'raise  # re-raise where d_datum is not None',
@@ -1248,5 +1250,4 @@ def test_regular_vs_ordered_dict_map_typeerror():
             stack = traceback.extract_tb(tb)
             filtered_stack = [
                 frame[3] for frame in stack if 'write_map' in frame[2]]
-            #assert filtered_stack == expected_write_record_stack_trace
-            print filtered_stack
+            assert filtered_stack == expected_write_record_stack_trace


### PR DESCRIPTION
Address #139.

We add a runtime check to `write_record()` and `write_map()`. For `dict`, use faster code. For other types, use equivalent but slower, generic code. There appears to be no meaningful impact on performance.

```
Before:

Writing 10000 records to one file...
... 10 runs averaged 0.00915930271149 seconds
Reading 10000 records from one file...
... 10 runs averaged 0.0144769668579 seconds

Writing 10000 records to one file...
... 10 runs averaged 0.0550956249237 seconds
Reading 10000 records from one file...
... 10 runs averaged 0.0886501789093 seconds

After:

Writing 10000 records to one file...
... 10 runs averaged 0.00916681289673 seconds
Reading 10000 records from one file...
... 10 runs averaged 0.0137780666351 seconds

Writing 10000 records to one file...
... 10 runs averaged 0.0546228170395 seconds
Reading 10000 records from one file...
... 10 runs averaged 0.0791359186172 seconds
```