### PR TITLE
Add wheel publishing to `publish.sh`

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -12,6 +12,8 @@ set -x
 
 make
 python setup.py sdist
+python setup.py bdist_wheel
+twine upload dist/fastavro-${ver}-*.whl
 twine upload dist/fastavro-${ver}.tar.gz
 # TODO: upload fails for some reason
 #conda build .
@@ -21,4 +23,5 @@ git push
 git push --tags
 # print sha so we can use it in conda-forge recipe
 sha256sum dist/fastavro-${ver}.tar.gz
+sha256sum dist/fastavro-${ver}-*.whl
 rm -fr build dist fastavro.egg-info/


### PR DESCRIPTION
Hi, lately installing `fastavro` is taking quite a bit time, because it is compiling using `Cython`.

To faster up entire package installation you could build wheels (https://packaging.python.org/tutorials/distributing-packages/#wheels).

