### PR TITLE
When installing from source package, use the included .c files

### DIFF
--- a/.travis_build_wheel.sh
+++ b/.travis_build_wheel.sh
@@ -13,4 +13,4 @@ TRAVIS_PYTHON_VERSION=$1
 TRAVIS_PYTHON_VERSION=${TRAVIS_PYTHON_VERSION/.}
 
 /opt/python/*${TRAVIS_PYTHON_VERSION}*m/bin/pip install cython
-/opt/python/*${TRAVIS_PYTHON_VERSION}*m/bin/python setup.py bdist_wheel
+FASTAVRO_USE_CYTHON=1 /opt/python/*${TRAVIS_PYTHON_VERSION}*m/bin/python setup.py bdist_wheel

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,11 +18,13 @@ build: off
 
 test_script:
     - "set PYTHONPATH=%cd%"
+    - "set FASTAVRO_USE_CYTHON=1"
     - "%PYTHON%\\python.exe setup.py build_ext --inplace"
     - "%PYTHON%\\python.exe -m pytest -v tests"
 
 after_test:
     # If tests are successful, create binary packages for the project.
+    - "set FASTAVRO_USE_CYTHON=1"
     - "%PYTHON%\\python.exe setup.py bdist_wheel"
     - ps: "ls dist"
 

--- a/publish.sh
+++ b/publish.sh
@@ -9,7 +9,7 @@ set -e
 set -x
 
 make
-python setup.py sdist
+FASTAVRO_USE_CYTHON=1 python setup.py sdist
 
 windows_wheels_url="https://ci.appveyor.com/project/scottbelden/fastavro"
 if [ ! -f dist/fastavro-${ver}-cp27-cp27m-win_amd64.whl ]; then

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -16,6 +16,6 @@ flake8 --config=.flake8.cython fastavro
 check-manifest
 
 # Build Cython modules
-python setup.py build_ext --inplace
+FASTAVRO_USE_CYTHON=1 python setup.py build_ext --inplace
 
 PYTHONPATH=${PWD} python -m pytest -v $@ tests

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ if not hasattr(sys, 'pypy_version_info'):
         Extension('fastavro._write', ["fastavro/_write" + ext]),
     ]
 
+
 def version():
     pyfile = 'fastavro/__init__.py'
     with open(pyfile) as fp:

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import ast
+import os
 import re
 import sys
 
@@ -9,17 +10,24 @@ except ImportError:
 
 from setuptools import Extension
 
+# publish.sh should set this variable to 1.
+try:
+    USE_CYTHON = int(os.getenv('FASTAVRO_USE_CYTHON'))
+except TypeError:
+    USE_CYTHON = False
+
+ext = '.pyx' if USE_CYTHON else '.c'
+
 # See http://setuptools.readthedocs.io/en/latest/setuptools.html\
 #     #distributing-extensions-compiled-with-pyrex
 ext_modules = []
 if not hasattr(sys, 'pypy_version_info'):
     ext_modules += [
-        Extension('fastavro._read', ["fastavro/_read.pyx"]),
-        Extension('fastavro._schema', ["fastavro/_schema.pyx"]),
-        Extension('fastavro._six', ["fastavro/_six.pyx"]),
-        Extension('fastavro._write', ["fastavro/_write.pyx"]),
+        Extension('fastavro._read', ["fastavro/_read" + ext]),
+        Extension('fastavro._schema', ["fastavro/_schema" + ext]),
+        Extension('fastavro._six', ["fastavro/_six" + ext]),
+        Extension('fastavro._write', ["fastavro/_write" + ext]),
     ]
-
 
 def version():
     pyfile = 'fastavro/__init__.py'
@@ -41,8 +49,11 @@ if not hasattr(sys, 'pypy_version_info'):
     cpython_requires = [
         # Setuptools 18.0 properly handles Cython extensions.
         'setuptools>=18.0',
-        'Cython',
     ]
+    if USE_CYTHON:
+        cpython_requires += [
+            'Cython',
+        ]
     install_requires += cpython_requires
     setup_requires += cpython_requires
 


### PR DESCRIPTION
PR for #144: Follow the [recommendations for distributing Cython packages](http://cython.readthedocs.io/en/latest/src/reference/compilation.html#distributing-cython-modules).

`setup.py` now checks for an environment variable `FASTAVRO_USE_CYTHON` when it runs. (Note: If it seems better, we could instead use a command-line option or some other technique.) Some techniques for using non-standard command-line options with `setup.py` are covered [here](https://stackoverflow.com/questions/677577/distutils-how-to-pass-a-user-defined-parameter-to-setup-py).

If the environment variable is set to `1` (which should be the case when running `setup.py develop` and during packaging/publishing), the library requires Cython and uses the `.pyx` files. If not set (which should be the case during installation), it does not require Cython and simply compiles the `.c` files which are assumed to be included with the package.

Benefits to users include:
* Faster installation
  * Does not download or install Cython
  * Does not have to convert `.pyx` files to `.c` files
* Avoids any potential Cython version issues with other packages used in the user's application. (We've seen versions of Cython that don't work with `fastavro` and certain versions of CPython, etc.)

To test these changes:
```
make
FASTAVRO_USE_CYTHON=1 python setup.py sdist
pushd ..
pyenv deactivate
pyenv uninstall -f fastavro-test
pyenv virtualenv fastavro-test
pyenv activate fastavro-test
pip install fastavro/dist/fastavro-0.17.7.tar.gz  # Or whatever the current version is
```