### PR TITLE
Fastavro 171 logical timestamp tz support

### DIFF
--- a/fastavro/_read.pyx
+++ b/fastavro/_read.pyx
@@ -25,6 +25,7 @@ from ._schema_common import SCHEMA_DEFS
 from ._read_common import (
     SchemaResolutionError, MAGIC, SYNC_SIZE, HEADER_SCHEMA
 )
+from ._timezone import utc
 from .const import (
     MCS_PER_HOUR, MCS_PER_MINUTE, MCS_PER_SECOND, MLS_PER_HOUR, MLS_PER_MINUTE,
     MLS_PER_SECOND, DAYS_SHIFT
@@ -136,7 +137,7 @@ cpdef inline read_boolean(ReaderBase fo, writer_schema=None, reader_schema=None)
 
 
 cpdef parse_timestamp(data, resolution):
-    return datetime.datetime.fromtimestamp(data / resolution)
+    return datetime.datetime.fromtimestamp(data / resolution, tz=utc)
 
 
 cpdef read_timestamp_millis(data, writer_schema=None, reader_schema=None):

--- a/fastavro/_read_py.py
+++ b/fastavro/_read_py.py
@@ -25,6 +25,7 @@ from ._schema_common import SCHEMA_DEFS
 from ._read_common import (
     SchemaResolutionError, MAGIC, SYNC_SIZE, HEADER_SCHEMA,
 )
+from ._timezone import utc
 from .const import (
     MCS_PER_HOUR, MCS_PER_MINUTE, MCS_PER_SECOND, MLS_PER_HOUR, MLS_PER_MINUTE,
     MLS_PER_SECOND, DAYS_SHIFT
@@ -119,7 +120,7 @@ def read_boolean(fo, writer_schema=None, reader_schema=None):
 
 
 def parse_timestamp(data, resolution):
-    return datetime.datetime.fromtimestamp(data / resolution)
+    return datetime.datetime.fromtimestamp(data / resolution, tz=utc)
 
 
 def read_timestamp_millis(data, writer_schema=None, reader_schema=None):

--- a/fastavro/_timezone.py
+++ b/fastavro/_timezone.py
@@ -1,30 +1,16 @@
-"""Implementation of abstract base class tzinfo"""
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+"""Timezone class for dealing with timezone-aware datetime objects
+Inspired by https://github.com/apache/avro/pull/207"""
 import time
 from datetime import datetime
 from datetime import timedelta
 from datetime import tzinfo
 
-"""Inspired by https://github.com/apache/avro/pull/207
-Obsoleted by datetime.timezone in py3.2"""
+
 
 
 class UTCTzinfo(tzinfo):
-
+    """Implementation of abstract base class tzinfo,
+    python >= 3.2 can use datetime.timezone.utc instead"""
     def utcoffset(self, dt):
         return timedelta(0)
 
@@ -38,12 +24,5 @@ class UTCTzinfo(tzinfo):
 utc = UTCTzinfo()
 
 # used to compute timestamp for tz-aware datetime objects
+# python >= 3.3 can use datetime.datetime.timestamp() instead
 epoch = datetime(1970, 1, 1, tzinfo=utc)
-
-
-def assert_naive_datetime_equal_to_tz_datetime(naive_datetime, tz_datetime):
-    # mktime appears to ignore microseconds, so do this manually
-    timestamp = int(time.mktime(naive_datetime.timetuple()))
-    timestamp += float(naive_datetime.microsecond) / 1000 / 1000
-    aware_datetime = datetime.fromtimestamp(timestamp, tz=utc)
-    assert aware_datetime == tz_datetime

--- a/fastavro/_timezone.py
+++ b/fastavro/_timezone.py
@@ -1,0 +1,49 @@
+"""Implementation of abstract base class tzinfo"""
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import time
+from datetime import datetime
+from datetime import timedelta
+from datetime import tzinfo
+
+"""Inspired by https://github.com/apache/avro/pull/207
+Obsoleted by datetime.timezone in py3.2"""
+
+
+class UTCTzinfo(tzinfo):
+
+    def utcoffset(self, dt):
+        return timedelta(0)
+
+    def tzname(self, dt):
+        return "UTC"
+
+    def dst(self, dt):
+        return timedelta(0)
+
+
+utc = UTCTzinfo()
+
+# used to compute timestamp for tz-aware datetime objects
+epoch = datetime(1970, 1, 1, tzinfo=utc)
+
+
+def assert_naive_datetime_equal_to_tz_datetime(naive_datetime, tz_datetime):
+    # mktime appears to ignore microseconds, so do this manually
+    timestamp = int(time.mktime(naive_datetime.timetuple()))
+    timestamp += float(naive_datetime.microsecond) / 1000 / 1000
+    aware_datetime = datetime.fromtimestamp(timestamp, tz=utc)
+    assert aware_datetime == tz_datetime

--- a/fastavro/_timezone.py
+++ b/fastavro/_timezone.py
@@ -1,11 +1,8 @@
 """Timezone class for dealing with timezone-aware datetime objects
 Inspired by https://github.com/apache/avro/pull/207"""
-import time
 from datetime import datetime
 from datetime import timedelta
 from datetime import tzinfo
-
-
 
 
 class UTCTzinfo(tzinfo):

--- a/fastavro/_write.pyx
+++ b/fastavro/_write.pyx
@@ -27,6 +27,7 @@ from ._schema import (
     extract_logical_type
 )
 from ._schema_common import SCHEMA_DEFS
+from ._timezone import epoch
 
 NoneType = type(None)
 
@@ -70,6 +71,10 @@ cpdef long64 prepare_timestamp_millis(object data, schema):
     cdef tm time_tuple
     if isinstance(data, datetime.datetime):
         if not has_timestamp_fn:
+            if data.tzinfo is not None:
+                return <long64>(<double>(
+                    <object>(data - epoch).total_seconds()) * MLS_PER_SECOND
+                )
             tt = data.timetuple()
             time_tuple.tm_sec = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 5)))
             time_tuple.tm_min = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 4)))
@@ -92,6 +97,10 @@ cpdef long64 prepare_timestamp_micros(object data, schema):
     cdef tm time_tuple
     if isinstance(data, datetime.datetime):
         if not has_timestamp_fn:
+            if data.tzinfo is not None:
+                return <long64>(<double>(
+                    <object>(data - epoch).total_seconds()) * MCS_PER_SECOND
+                )
             tt = data.timetuple()
             time_tuple.tm_sec = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 5)))
             time_tuple.tm_min = PyInt_AS_LONG(<object>(PyTuple_GET_ITEM(tt, 4)))

--- a/fastavro/_write_py.py
+++ b/fastavro/_write_py.py
@@ -29,6 +29,7 @@ from .schema import (
     extract_logical_type
 )
 from ._schema_common import SCHEMA_DEFS
+from ._timezone import epoch
 
 NoneType = type(None)
 
@@ -46,6 +47,9 @@ def write_boolean(fo, datum, schema=None):
 
 def prepare_timestamp_millis(data, schema):
     if isinstance(data, datetime.datetime):
+        if data.tzinfo is not None:
+            delta = (data - epoch)
+            return int(delta.total_seconds() * MLS_PER_SECOND)
         t = int(time.mktime(data.timetuple())) * MLS_PER_SECOND + int(
             data.microsecond / 1000)
         return t
@@ -55,6 +59,9 @@ def prepare_timestamp_millis(data, schema):
 
 def prepare_timestamp_micros(data, schema):
     if isinstance(data, datetime.datetime):
+        if data.tzinfo is not None:
+            delta = (data - epoch)
+            return int(delta.total_seconds() * MCS_PER_SECOND)
         t = int(time.mktime(data.timetuple())) * MCS_PER_SECOND + \
             data.microsecond
         return t

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,11 @@
+import datetime
 import pytest
+import time
 
 from fastavro.read import READERS
 from fastavro.write import WRITERS
 from fastavro._schema_common import SCHEMA_DEFS
+from fastavro._timezone import utc
 
 
 @pytest.fixture(scope='function')
@@ -22,3 +25,11 @@ def clean_readers_writers_and_schemas():
         diff = set(repo) - keys
         for key in diff:
             del repo[key]
+
+
+def assert_naive_datetime_equal_to_tz_datetime(naive_datetime, tz_datetime):
+    # mktime appears to ignore microseconds, so do this manually
+    timestamp = int(time.mktime(naive_datetime.timetuple()))
+    timestamp += float(naive_datetime.microsecond) / 1000 / 1000
+    aware_datetime = datetime.datetime.fromtimestamp(timestamp, tz=utc)
+    assert aware_datetime == tz_datetime

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 from io import BytesIO
 
 import fastavro
-from fastavro._timezone import assert_naive_datetime_equal_to_tz_datetime
+from conftest import assert_naive_datetime_equal_to_tz_datetime
 
 schema = {
     "fields": [

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 from io import BytesIO
 
 import fastavro
-from conftest import assert_naive_datetime_equal_to_tz_datetime
+from .conftest import assert_naive_datetime_equal_to_tz_datetime
 
 schema = {
     "fields": [

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from io import BytesIO
 
 import fastavro
+from fastavro._timezone import assert_naive_datetime_equal_to_tz_datetime
 
 schema = {
     "fields": [
@@ -87,7 +88,18 @@ def test_complex_schema():
     }
     binary = serialize(schema, data1)
     data2 = deserialize(schema, binary)
-    assert (data1 == data2)
+    assert len(data1) == len(data2)
+    for field in [
+        'array_string',
+        'array_bytes_decimal',
+        'array_fixed_decimal',
+        'array_record',
+    ]:
+        assert data1[field] == data2[field]
+    assert_naive_datetime_equal_to_tz_datetime(
+        data1['multi_union_time'],
+        data2['multi_union_time']
+    )
 
 
 def test_complex_schema_nulls():

--- a/tests/test_logical_types.py
+++ b/tests/test_logical_types.py
@@ -1,6 +1,5 @@
 import fastavro
 from fastavro.__main__ import _clean_json_record
-from fastavro._timezone import assert_naive_datetime_equal_to_tz_datetime
 import pytest
 
 from decimal import Decimal
@@ -9,6 +8,8 @@ from uuid import uuid4
 import datetime
 import sys
 import os
+
+from conftest import assert_naive_datetime_equal_to_tz_datetime
 
 
 schema = {

--- a/tests/test_logical_types.py
+++ b/tests/test_logical_types.py
@@ -9,7 +9,7 @@ import datetime
 import sys
 import os
 
-from conftest import assert_naive_datetime_equal_to_tz_datetime
+from .conftest import assert_naive_datetime_equal_to_tz_datetime
 
 
 schema = {

--- a/tests/test_logical_types.py
+++ b/tests/test_logical_types.py
@@ -1,5 +1,6 @@
 import fastavro
 from fastavro.__main__ import _clean_json_record
+from fastavro._timezone import assert_naive_datetime_equal_to_tz_datetime
 import pytest
 
 from decimal import Decimal
@@ -71,7 +72,10 @@ def test_logical_types():
     binary = serialize(schema, data1)
     data2 = deserialize(schema, binary)
     assert (data1['date'] == data2['date'])
-    assert (data1['timestamp-micros'] == data2['timestamp-micros'])
+    assert_naive_datetime_equal_to_tz_datetime(
+        data1['timestamp-micros'],
+        data2['timestamp-micros'],
+    )
     assert (int(data1['timestamp-millis'].microsecond / 1000) * 1000
             == data2['timestamp-millis'].microsecond)
     assert (int(data1['time-millis'].microsecond / 1000) * 1000

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -1,0 +1,194 @@
+import datetime
+from io import BytesIO
+
+import fastavro
+from fastavro.const import MCS_PER_SECOND, MLS_PER_SECOND
+from fastavro import _timezone as tz
+from fastavro._write_py import prepare_timestamp_micros
+from fastavro._write_py import prepare_timestamp_millis
+import pytest
+
+
+schema = {
+    "fields": [
+          {
+              "name": "timestamp-millis",
+              "type": {'type': 'long', 'logicalType': 'timestamp-millis'}
+          },
+          {
+              "name": "timestamp-micros",
+              "type": {'type': 'long', 'logicalType': 'timestamp-micros'}
+          },
+    ],
+    "namespace": "namespace",
+    "name": "name",
+    "type": "record"
+}
+
+
+# Test Time Zone with fixed offset and 1 hr DST
+class TSTTzinfo(datetime.tzinfo):
+    def utcoffset(self, dt):
+        return datetime.timedelta(hours=10)
+
+    def tzname(self, dt):
+        return "TST"
+
+    def dst(self, dt):
+        return datetime.timedelta(0)
+
+
+tst = TSTTzinfo()
+
+
+# Test Time Zone with fixed offset and 1 hr DST
+class TDTTzinfo(datetime.tzinfo):
+    def utcoffset(self, dt):
+        return datetime.timedelta(hours=10)
+
+    def tzname(self, dt):
+        return "TDT"
+
+    def dst(self, dt):
+        return datetime.timedelta(hours=1)
+
+
+tdt = TDTTzinfo()
+
+epoch_naive = datetime.datetime(1970, 1, 1, 0, 0, 0, 0)
+
+
+def serialize(schema, data):
+    bytes_writer = BytesIO()
+    fastavro.schemaless_writer(bytes_writer, schema, data)
+    return bytes_writer.getvalue()
+
+
+def deserialize(schema, binary):
+    bytes_writer = BytesIO()
+    bytes_writer.write(binary)
+    bytes_writer.seek(0)
+
+    res = fastavro.schemaless_reader(bytes_writer, schema)
+    return res
+
+
+def timestamp_mls_from_timestamp(timestamp):
+    # need to remove precision from microseconds field
+    mls = int(timestamp.microsecond / 1000) * 1000
+    return datetime.datetime(
+        year=timestamp.year,
+        month=timestamp.month,
+        day=timestamp.day,
+        hour=timestamp.hour,
+        minute=timestamp.minute,
+        second=timestamp.second,
+        microsecond=mls,
+        tzinfo=timestamp.tzinfo,
+    )
+
+
+def test_tz_attributes():
+    assert tz.utc.tzname(None) == 'UTC'
+    assert tz.utc.utcoffset(None) == datetime.timedelta(0)
+    assert tz.utc.dst(None) == datetime.timedelta(0)
+    assert tst.tzname(None) == 'TST'
+    assert tst.utcoffset(None) != tz.utc.utcoffset(None)
+    assert tdt.tzname(None) == 'TDT'
+    assert tdt.utcoffset(None) == tst.utcoffset(None)
+    assert tdt.dst(None) != tst.dst(None)
+
+
+@pytest.fixture(scope='session')
+def timestamp_data():
+    # can use current time since it will be adapted to being tz aware
+    timestamp = datetime.datetime.now(tz=tz.utc)
+    return {
+        'timestamp-millis': timestamp_mls_from_timestamp(timestamp),
+        'timestamp-micros': timestamp,
+    }
+
+
+@pytest.fixture(scope='session')
+def timestamp_data_naive():
+    # have to pick a specific date
+    timestamp = epoch_naive
+
+    return {
+        'timestamp-millis': timestamp_mls_from_timestamp(timestamp),
+        'timestamp-micros': timestamp,
+    }
+
+
+@pytest.fixture(scope='session')
+def read_data(timestamp_data):
+    binary = serialize(schema, timestamp_data)
+    return deserialize(schema, binary)
+
+
+@pytest.fixture(scope='session')
+def read_data_naive(timestamp_data_naive):
+    binary = serialize(schema, timestamp_data_naive)
+    return deserialize(schema, binary)
+
+
+def test_timestamp_micros_tz_input(timestamp_data, read_data):
+    original = timestamp_data['timestamp-micros']
+    assert original.tzinfo is not None
+    read = read_data['timestamp-micros']
+    assert read.tzinfo is not None
+    assert original == read
+    read_in_test_tz = read.astimezone(tst)
+    assert original == read_in_test_tz
+
+
+def test_timestamp_millis_tz_input(timestamp_data, read_data):
+    original = timestamp_data['timestamp-millis']
+    assert original.tzinfo is not None
+    read = read_data['timestamp-millis']
+    assert read.tzinfo is not None
+    assert original == read
+    read_in_test_tz = read.astimezone(tst)
+    assert original == read_in_test_tz
+
+
+def test_timestamp_micros_naive_input(timestamp_data_naive, read_data_naive):
+    original = timestamp_data_naive['timestamp-micros']
+    assert original.tzinfo is None
+    read = read_data_naive['timestamp-micros']
+    assert read.tzinfo is not None
+    # naive logic depends on system timezone and cannot check time value
+
+
+def test_prepare_timestamp_micros():
+    # seconds from epoch == 1234567890
+    reference_time = datetime.datetime(2009, 2, 13, 23, 31, 30, tzinfo=tz.utc)
+    mcs_from_epoch = 1234567890 * MCS_PER_SECOND
+    assert prepare_timestamp_micros(reference_time, schema) == mcs_from_epoch
+    timestamp_tst = reference_time.astimezone(tst)
+    assert (
+        prepare_timestamp_micros(reference_time, schema) ==
+        prepare_timestamp_micros(timestamp_tst, schema)
+    )
+    timestamp_tdt = reference_time.astimezone(tdt)
+    assert (
+            prepare_timestamp_micros(reference_time, schema) ==
+            prepare_timestamp_micros(timestamp_tdt, schema)
+    )
+
+
+def test_prepare_timestamp_millis():
+    # seconds from epoch == 1234567890
+    reference_time = datetime.datetime(2009, 2, 13, 23, 31, 30, tzinfo=tz.utc)
+    mcs_from_epoch = 1234567890 * MLS_PER_SECOND
+    assert prepare_timestamp_millis(reference_time, schema) == mcs_from_epoch
+    timestamp_tst = reference_time.astimezone(tst)
+    assert (
+        prepare_timestamp_millis(reference_time, schema) ==
+        prepare_timestamp_millis(timestamp_tst, schema)
+    )
+    timestamp_tdt = reference_time.astimezone(tdt)
+    assert (
+            prepare_timestamp_millis(reference_time, schema) ==
+            prepare_timestamp_millis(timestamp_tdt, schema)
+    )

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -157,7 +157,21 @@ def test_timestamp_micros_naive_input(timestamp_data_naive, read_data_naive):
     assert original.tzinfo is None
     read = read_data_naive['timestamp-micros']
     assert read.tzinfo is not None
-    # naive logic depends on system timezone and cannot check time value
+    tz.assert_naive_datetime_equal_to_tz_datetime(
+        original,
+        read
+    )
+
+
+def test_timestamp_millis_naive_input(timestamp_data_naive, read_data_naive):
+    original = timestamp_data_naive['timestamp-millis']
+    assert original.tzinfo is None
+    read = read_data_naive['timestamp-millis']
+    assert read.tzinfo is not None
+    tz.assert_naive_datetime_equal_to_tz_datetime(
+        original,
+        read
+    )
 
 
 def test_prepare_timestamp_micros():

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -7,7 +7,7 @@ from fastavro import _timezone as tz
 from fastavro._write_py import prepare_timestamp_micros
 from fastavro._write_py import prepare_timestamp_millis
 import pytest
-from conftest import assert_naive_datetime_equal_to_tz_datetime
+from .conftest import assert_naive_datetime_equal_to_tz_datetime
 
 
 schema = {


### PR DESCRIPTION
Fix for Issue 171 (adding in tzaware datetime objects)

One thing to note is that the output Python datetime object is now TZ-aware. TZ-aware datetime objects can't be compared with TZ-naive objects, so some downstream users might have problems if they rely on datetime objects being TZ-naive. However, the code branch for a Python2.7 (i.e. no datetime.timestamp() method) remains unchanged for TZ-naive objects when serializing the object as a long for Avro encoding.

Also, sorry if I missed any prep for the PR, it seemed like the "Hacking" section was talking about after a PR to fastavro gets merged... so I didn't do any of those steps. Lemme know if there's stuff I need to do from that section.