### PR TITLE
fix overzealous validation errors

### DIFF
--- a/fastavro/_validation.pyx
+++ b/fastavro/_validation.pyx
@@ -155,7 +155,7 @@ cdef inline bint validate_union(object datum, list schema, str parent_ns=None,
                 return True
         except ValidationError as e:
             errors.extend(e.errors)
-    if raise_errors and errors:
+    if raise_errors:
         raise ValidationError(*errors)
     return False
 

--- a/fastavro/_validation.pyx
+++ b/fastavro/_validation.pyx
@@ -155,7 +155,7 @@ cdef inline bint validate_union(object datum, list schema, str parent_ns=None,
                 return True
         except ValidationError as e:
             errors.extend(e.errors)
-    if raise_errors:
+    if raise_errors and errors:
         raise ValidationError(*errors)
     return False
 
@@ -235,6 +235,6 @@ cpdef validate_many(records, schema, bint raise_errors=True):
             results.append(result)
         except ValidationError as e:
             errors.extend(e.errors)
-    if raise_errors:
+    if raise_errors and errors:
         raise ValidationError(*errors)
     return all(results)

--- a/fastavro/_validation_py.py
+++ b/fastavro/_validation_py.py
@@ -412,6 +412,6 @@ def validate_many(records, schema, raise_errors=True):
             results.append(validate(record, schema, raise_errors=raise_errors))
         except ValidationError as e:
             errors.extend(e.errors)
-    if raise_errors:
+    if raise_errors and errors:
         raise ValidationError(*errors)
     return all(results)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -86,6 +86,7 @@ def test_validate_true():
     ]
 
     assert validation_boolean(schema, *records) is True
+    validation_raise(schema, *records)
 
 
 def test_validate_string_in_int_null_raises():


### PR DESCRIPTION
Before this change, benchmarking spuriously fails:

```bash
./run-tests.sh
python benchmark/benchmark.py
```
```
Small - 1 rec - 100,000 runs
Writing 1 records to one file...
... 100000 runs averaged 2.65738511086e-05 seconds
Reading 1 records from one file...
... 100000 runs averaged 2.72266125679e-05 seconds
Validating 1 records from one file...
Traceback (most recent call last):
  File "benchmark/benchmark.py", line 161, in <module>
    valid = validater(schema, original_records, runs=num_runs)
  File "benchmark/benchmark.py", line 28, in validater
    valid = validate_many(records, schema)
  File "fastavro/_validation.pyx", line 228, in fastavro._validation.validate_many
    cpdef validate_many(records, schema, bint raise_errors=True):
  File "fastavro/_validation.pyx", line 239, in fastavro._validation.validate_many
    raise ValidationError(*errors)
fastavro._validate_common.ValidationError: []
```

`validate_many` is the culprit, though mysteriously `validate_union` seems to have the same issue (fixed here), but is apparently never exercised by any tests?